### PR TITLE
fix: correct STATSPACK parameter name

### DIFF
--- a/.bumpversion.cfg
+++ b/.bumpversion.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 4.3.24
+current_version = 4.3.25
 commit = False
 tag = False
 

--- a/scripts/collector/mysql/collect-data.sh
+++ b/scripts/collector/mysql/collect-data.sh
@@ -16,7 +16,7 @@
 
 ### Setup directories needed for execution
 #############################################################################
-OpVersion="4.3.24"
+OpVersion="4.3.25"
 
 LOCALE=$(echo $LANG | cut -d '.' -f 1)
 export LANG=C

--- a/scripts/collector/oracle/README.txt
+++ b/scripts/collector/oracle/README.txt
@@ -74,11 +74,45 @@ for analysis by Database Migration Assessment.
 
     a) Execute collect-data.sh, passing the database connection string and indicator on whether to use AWR/ASH diagnostic data.
 
+       Parameters:
+      
+       Connection definition must one of:
+           {
+             --connectionStr       Oracle EasyConnect string formatted as {user}/{password}@//{db host}:{listener port}/{service name}.
+            or
+             --hostName            Database server host name.
+             --port                Database Listener port.
+             --databaseService     Database service name.
+             --collectionUserName  Database user name.
+             --collectionUserPass  Database password.
+           }
+       Performance statistics source
+           --statsSrc              Required. Must be one of AWR, STATSPACK, NONE.
+   
+   
+      Examples:
+   
         To use the AWR/ASH data:
-        ./collect-data.sh 'username/password@//hostname.domain.com:1521/dbname.domain.com' UseDiagnostics
+          ./collect-data.sh --connectionStr {user}/{password}@//{db host}:{listener port}/{service name} --statsSrc AWR
+         or
+          ./collect-data.sh --collectionUserName {user} --collectionUserPass {password} --hostName {db host} --port {listener port} --databaseService {service name} --statsSrc AWR
+  
 
-        To prevent use of AWR/ASH data and use STATSPACK data (if available) instead:
-        ./collect-data.sh 'username/password@//hostname.domain.com:1521/dbname.domain.com' NoDiagnostics
+        To use the STATSPACK data:
+          ./collect-data.sh --connectionStr {user}/{password}@//{db host}:{listener port}/{service name} --statsSrc STATSPACK
+         or
+          ./collect-data.sh --collectionUserName {user} --collectionUserPass {password} --hostName {db host} --port {listener port} --databaseService {service name} --statsSrc STATSPACK
+
+
+
+        Collections can be run as SYS if needed by setting ORACLE_SID and running on the database host:
+        
+          ./collect-data.sh --connectionStr '/ as sysdba' --statsSrc AWR 
+
+         or to avoid using the licensed Oracle Tuning and Diagnostics pack data:
+
+          ./collect-data.sh  --connectionStr '/ as sysdba' --statsSrc STATSPACK
+
 
         Notes:
             1) Google Database Migration Assessment Data Extractor extracts data for the entire database. In multitenant

--- a/scripts/collector/oracle/collect-data.sh
+++ b/scripts/collector/oracle/collect-data.sh
@@ -16,7 +16,7 @@
 
 ### Setup directories needed for execution
 #############################################################################
-OpVersion="4.3.24"
+OpVersion="4.3.25"
 dbmajor=""
 
 LOCALE=$(echo $LANG | cut -d '.' -f 1)

--- a/scripts/collector/oracle/collect-data.sh
+++ b/scripts/collector/oracle/collect-data.sh
@@ -339,7 +339,7 @@ manualUniqueId=""
 
  if [[ "${statsSrc}" = "awr" ]]; then
           DIAGPACKACCESS="UseDiagnostics"
- elif [[ "${stasSrc}" = "statspack" ]] ; then
+ elif [[ "${statsSrc}" = "statspack" ]] ; then
           DIAGPACKACCESS="NoDiagnostics"
  else 
 	 echo No performance data will be collected.

--- a/scripts/collector/postgres/collect-data.sh
+++ b/scripts/collector/postgres/collect-data.sh
@@ -16,7 +16,7 @@
 
 ### Setup directories needed for execution
 #############################################################################
-OpVersion="4.3.24"
+OpVersion="4.3.25"
 
 LOCALE=$(echo $LANG | cut -d '.' -f 1)
 export LANG=C

--- a/scripts/collector/sqlserver/instanceReview.ps1
+++ b/scripts/collector/sqlserver/instanceReview.ps1
@@ -151,7 +151,7 @@ $current_ts = $values[4]
 $pkey = $values[5]
 $dmaSourceId = $dmaSourceIdObj[0]
 
-$op_version = "4.3.24"
+$op_version = "4.3.25"
 
 if ($ignorePerfmon -eq "true") {
     $perfCounterLabel = "NoPerfCounter"

--- a/scripts/masker/dma-collection-masker
+++ b/scripts/masker/dma-collection-masker
@@ -33,7 +33,7 @@ __all__ = [
     "run_masker",
 ]
 
-__version__ = "4.3.24"
+__version__ = "4.3.25"
 
 logger = logging.getLogger(__name__)
 


### PR DESCRIPTION
Correct misspelling of parameter controlling STATSPACK access.
Update README.txt with correct parameter names and examples, to match  the docs.