### PR TITLE
feat: Adding dmaSQLServerHWSpecs.ps1 to collect the HW Shape info

### DIFF
--- a/scripts/collector/sqlserver/dmaSQLServerHWSpecs.ps1
+++ b/scripts/collector/sqlserver/dmaSQLServerHWSpecs.ps1
@@ -33,9 +33,9 @@
 #>
 param (
 	[Parameter(
-		Mandatory=$True,
+		Mandatory=$False,
 		HelpMessage="The computer name"
-	)][string]$computerName,
+	)][string]$computerName = $env:COMPUTERNAME,
 	[Parameter(
 		Mandatory=$True,
 		HelpMessage="The Output path"
@@ -57,11 +57,18 @@ param (
 try {
 	Write-Host "Params: computer:$computerName, dma_src: $dmaSourceId, output:$outputPath"
 
+	$credential = $null
+	# This will create a pop up for the user to enter credentials for shape sizing collection.
+	if ($computerName -ne $env:COMPUTERNAME) {
+		Write-Host "Identified a remote computer, please add credentials"
+       $credential = Get-Credential -Message "Please enter system credentials for machine shape sizing:"
+	}
+
 	# Logical cores count.
-	$cores=(Get-WmiObject Win32_Processor -ComputerName $computerName | Measure-Object -Property NumberOfCores -Sum).Sum
+	$cores=(Get-WmiObject Win32_Processor -Credential $credential -ComputerName $computerName | Measure-Object -Property NumberOfCores -Sum).Sum
 	
 	# Total memory in bytes.
-	$memoryBytes=(Get-WmiObject Win32_PhysicalMemory -ComputerName $computerName | Measure-Object -Property Capacity -Sum).Sum
+	$memoryBytes=(Get-WmiObject Win32_PhysicalMemory -Credential $credential -ComputerName $computerName | Measure-Object -Property Capacity -Sum).Sum
 	
 	# CSV data.
 	$csvData = [PSCustomObject]@{

--- a/scripts/collector/sqlserver/dmaSQLServerHWSpecs.ps1
+++ b/scripts/collector/sqlserver/dmaSQLServerHWSpecs.ps1
@@ -65,7 +65,7 @@ try {
 	}
 
 	# Logical cores count.
-	$cores=(Get-WmiObject Win32_Processor -Credential $credential -ComputerName $computerName | Measure-Object -Property NumberOfCores -Sum).Sum
+	$cores=(Get-WmiObject Win32_Processor -Credential $credential -ComputerName $computerName | Measure-Object -Property NumberOfLogicalProcessors -Sum).Sum
 	
 	# Total memory in bytes.
 	$memoryBytes=(Get-WmiObject Win32_PhysicalMemory -Credential $credential -ComputerName $computerName | Measure-Object -Property Capacity -Sum).Sum

--- a/scripts/collector/sqlserver/dmaSQLServerHWSpecs.ps1
+++ b/scripts/collector/sqlserver/dmaSQLServerHWSpecs.ps1
@@ -89,6 +89,5 @@ catch {
 	WriteLog -logLocation $logLocation -logMessage "ERROR - Failed fetching machine HW specs of $computerName" -logOperation "FILE"	
 
 	# Writing Empty CSV File.
-	$headers = '"pkey"|"dma_source_id"|"dma_manual_id"|"computer_name"|"cores"|"memory_bytes"'
-	$headers | Out-File -FilePath $outputPath -Encoding UTF8
+	Set-Content -Path $outputPath -Encoding UTF8 -Value '"pkey"|"dma_source_id"|"dma_manual_id"|"computer_name"|"cores"|"memory_bytes"'
 }

--- a/scripts/collector/sqlserver/dmaSQLServerHWSpecs.ps1
+++ b/scripts/collector/sqlserver/dmaSQLServerHWSpecs.ps1
@@ -57,7 +57,7 @@ param (
 	[Parameter(
 		Mandatory=$False,
 		HelpMessage="The log file location"
-	)][string]$logLocation="$PSScriptRoot\dmaSqlServerHWSpecs.log"
+	)][string]$logLocation="dmaSqlServerHWSpecs.log"
 )
 
 Import-Module $PSScriptRoot\dmaCollectorCommonFunctions.psm1

--- a/scripts/collector/sqlserver/dmaSQLServerHWSpecs.ps1
+++ b/scripts/collector/sqlserver/dmaSQLServerHWSpecs.ps1
@@ -57,18 +57,11 @@ param (
 try {
 	Write-Host "Params: computer:$computerName, dma_src: $dmaSourceId, output:$outputPath"
 
-	$credential = $null
-	# This will create a pop up for the user to enter credentials for shape sizing collection.
-	if ($computerName -ne $env:COMPUTERNAME) {
-		Write-Host "Identified a remote computer, please add credentials"
-       $credential = Get-Credential -Message "Please enter system credentials for machine shape sizing:"
-	}
-
 	# Logical cores count.
-	$cores=(Get-WmiObject Win32_Processor -Credential $credential -ComputerName $computerName | Measure-Object -Property NumberOfLogicalProcessors -Sum).Sum
+	$cores=(Get-WmiObject Win32_Processor -ComputerName $computerName | Measure-Object -Property NumberOfLogicalProcessors -Sum).Sum
 	
 	# Total memory in bytes.
-	$memoryBytes=(Get-WmiObject Win32_PhysicalMemory -Credential $credential -ComputerName $computerName | Measure-Object -Property Capacity -Sum).Sum
+	$memoryBytes=(Get-WmiObject Win32_PhysicalMemory -ComputerName $computerName | Measure-Object -Property Capacity -Sum).Sum
 	
 	# CSV data.
 	$csvData = [PSCustomObject]@{
@@ -85,5 +78,5 @@ try {
 	Write-Host "Success to retrieve information from $computerName."
 }
 catch {
-	Write-Host "Failed to retrieve information from $computerName."
+	Write-Host "Failed to retrieve hardware information from $computerName, skipping."
 }

--- a/scripts/collector/sqlserver/dmaSQLServerHWSpecs.ps1
+++ b/scripts/collector/sqlserver/dmaSQLServerHWSpecs.ps1
@@ -17,7 +17,7 @@
 .DESCRIPTION
     Collects HW Specs using Get-WmiObject to be uploaded to Google Database Migration Assistant for MS SQL Server.
 .PARAMETER computerName
-    The target computer name to collect the HW specs from (Required).
+    The target computer name to collect the HW specs from (Optional).
 .PARAMETER outputPath
     The output full path of the csv that this scripts creates (Required).
 .PARAMETER pkey

--- a/scripts/collector/sqlserver/dmaSQLServerHWSpecs.ps1
+++ b/scripts/collector/sqlserver/dmaSQLServerHWSpecs.ps1
@@ -65,8 +65,11 @@ Import-Module $PSScriptRoot\dmaCollectorCommonFunctions.psm1
 try {
 	WriteLog -logLocation $logLocation -logMessage "Fetching machine HW specs from computer:$computerName and storing it in output:$outputPath" -logOperation "FILE"
 
+	# Physical cores count.
+	$PhysicalCpuCount=(Get-WmiObject Win32_Processor -ComputerName $computerName | Measure-Object -Property NumberOfCores -Sum).Sum
+
 	# Logical cores count.
-	$cores=(Get-WmiObject Win32_Processor -ComputerName $computerName | Measure-Object -Property NumberOfLogicalProcessors -Sum).Sum
+	$LogicalCpuCount=(Get-WmiObject Win32_Processor -ComputerName $computerName | Measure-Object -Property NumberOfLogicalProcessors -Sum).Sum
 	
 	# Total memory in bytes.
 	$memoryBytes=(Get-WmiObject Win32_PhysicalMemory -ComputerName $computerName | Measure-Object -Property Capacity -Sum).Sum
@@ -77,8 +80,9 @@ try {
 		"dma_source_id" = $dmaSourceId
 		"dma_manual_id" = $dmaManualId
 		"computer_name" = $computerName
-		"cores" = $cores
-		"memory_bytes" = $memoryBytes
+		"PhysicalCpuCount" = $PhysicalCpuCount
+		"LogicalCpuCount" = $LogicalCpuCount
+		"TotalOSMemoryMB" = $memoryBytes/1024/1024
 	}
 	
 	# Writing to csv.
@@ -89,5 +93,5 @@ catch {
 	WriteLog -logLocation $logLocation -logMessage "ERROR - Failed fetching machine HW specs of $computerName" -logOperation "FILE"	
 
 	# Writing Empty CSV File.
-	Set-Content -Path $outputPath -Encoding UTF8 -Value '"pkey"|"dma_source_id"|"dma_manual_id"|"computer_name"|"cores"|"memory_bytes"'
+	Set-Content -Path $outputPath -Encoding UTF8 -Value '"pkey"|"dma_source_id"|"dma_manual_id"|"computer_name"|"PhysicalCpuCount"|"LogicalCpuCount"|"TotalOSMemoryMB"'
 }

--- a/scripts/collector/sqlserver/dmaSQLServerHWSpecs.ps1
+++ b/scripts/collector/sqlserver/dmaSQLServerHWSpecs.ps1
@@ -82,9 +82,20 @@ try {
 	}
 	
 	# Writing to csv.
-	$csvData | Export-Csv -Path $outputPath -Delimiter "|" -NoTypeInformation
+	$csvData | Export-Csv -Path $outputPath -Delimiter "|" -NoTypeInformation -Encoding UTF8
 	WriteLog -logLocation $logLocation -logMessage "Successfully fetched machine HW specs of $computerName to output:$outputPath" -logOperation "FILE"	
 }
 catch {
 	WriteLog -logLocation $logLocation -logMessage "ERROR - Failed fetching machine HW specs of $computerName" -logOperation "FILE"	
+	# Empty CSV data.
+	$csvData = [PSCustomObject]@{
+		"pkey" = $null
+		"dma_source_id" = $null
+		"dma_manual_id" = $null
+		"computer_name" = $null
+		"cores" = $null
+		"memory_bytes" = $null
+	}
+	# Writing headers only to csv.
+	$csvData | Export-Csv -Path $outputPath -Delimiter "|" -NoTypeInformation -Encoding UTF8
 }

--- a/scripts/collector/sqlserver/dmaSQLServerHWSpecs.ps1
+++ b/scripts/collector/sqlserver/dmaSQLServerHWSpecs.ps1
@@ -79,7 +79,7 @@ try {
 		"pkey" = $pkey
 		"dma_source_id" = $dmaSourceId
 		"dma_manual_id" = $dmaManualId
-		"computer_name" = $computerName
+		"MachineName" = $computerName
 		"PhysicalCpuCount" = $PhysicalCpuCount
 		"LogicalCpuCount" = $LogicalCpuCount
 		"TotalOSMemoryMB" = $memoryBytes/1024/1024
@@ -93,5 +93,5 @@ catch {
 	WriteLog -logLocation $logLocation -logMessage "ERROR - Failed fetching machine HW specs of $computerName" -logOperation "FILE"	
 
 	# Writing Empty CSV File.
-	Set-Content -Path $outputPath -Encoding UTF8 -Value '"pkey"|"dma_source_id"|"dma_manual_id"|"computer_name"|"PhysicalCpuCount"|"LogicalCpuCount"|"TotalOSMemoryMB"'
+	Set-Content -Path $outputPath -Encoding UTF8 -Value '"pkey"|"dma_source_id"|"dma_manual_id"|"MachineName"|"PhysicalCpuCount"|"LogicalCpuCount"|"TotalOSMemoryMB"'
 }

--- a/scripts/collector/sqlserver/dmaSQLServerHWSpecs.ps1
+++ b/scripts/collector/sqlserver/dmaSQLServerHWSpecs.ps1
@@ -1,0 +1,82 @@
+# Copyright 2023 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+<#
+.SYNOPSIS
+    .
+.DESCRIPTION
+    Collects HW Specs using Get-WmiObject to be uploaded to Google Database Migration Assistant for MS SQL Server.
+.PARAMETER computerName
+    The target computer name to collect the HW specs from (Required).
+.PARAMETER outputPath
+    The output full path of the csv that this scripts creates (Required).
+.PARAMETER pkey
+    Final Output Directory (Required).
+.PARAMETER dmaSourceId
+    DMA derived unique id (Required).
+.PARAMETER dmaManualId
+    Customer Manual Unique ID or dma manual unique id (Optional).
+.EXAMPLE
+    C:\dmaSQLServerHWSpecs.ps1 -computerName localhost -outputPath a.out -pkey pkey1 -dmaSourceId src1
+.NOTES
+    https://googlecloudplatform.github.io/database-assessment/
+#>
+param (
+	[Parameter(
+		Mandatory=$True,
+		HelpMessage="The computer name"
+	)][string]$computerName,
+	[Parameter(
+		Mandatory=$True,
+		HelpMessage="The Output path"
+	)][string]$outputPath,
+	[Parameter(
+		Mandatory=$True,
+		HelpMessage="The pkey value"
+	)][string]$pkey,
+	[Parameter(
+		Mandatory=$True,
+		HelpMessage="The dma_source_id"
+	)][string]$dmaSourceId,
+	[Parameter(
+		Mandatory=$False,
+		HelpMessage="The dma_manual_id"
+	)][string]$dmaManualId="NA"
+)
+
+try {
+	Write-Host "Params: computer:$computerName, dma_src: $dmaSourceId, output:$outputPath"
+
+	# Logical cores count.
+	$cores=(Get-WmiObject Win32_Processor -ComputerName $computerName | Measure-Object -Property NumberOfCores -Sum).Sum
+	
+	# Total memory in bytes.
+	$memoryBytes=(Get-WmiObject Win32_PhysicalMemory -ComputerName $computerName | Measure-Object -Property Capacity -Sum).Sum
+	
+	# CSV data.
+	$csvData = [PSCustomObject]@{
+		"pkey" = $pkey
+		"dma_source_id" = $dmaSourceId
+		"dma_manual_id" = $dmaManualId
+		"computer_name" = $computerName
+		"cores" = $cores
+		"memory_bytes" = $memoryBytes
+	}
+	
+	# Writing to csv.
+	$csvData | Export-Csv -Path $outputPath -Delimiter "|" -NoTypeInformation
+	Write-Host "Success to retrieve information from $computerName."
+}
+catch {
+	Write-Host "Failed to retrieve information from $computerName."
+}

--- a/scripts/collector/sqlserver/dmaSQLServerHWSpecs.ps1
+++ b/scripts/collector/sqlserver/dmaSQLServerHWSpecs.ps1
@@ -26,6 +26,8 @@
     DMA derived unique id (Required).
 .PARAMETER dmaManualId
     Customer Manual Unique ID or dma manual unique id (Optional).
+.PARAMETER logLocation
+    Location of log file to output the script (Optional).
 .EXAMPLE
     C:\dmaSQLServerHWSpecs.ps1 -computerName localhost -outputPath a.out -pkey pkey1 -dmaSourceId src1
 .NOTES
@@ -51,11 +53,17 @@ param (
 	[Parameter(
 		Mandatory=$False,
 		HelpMessage="The dma_manual_id"
-	)][string]$dmaManualId="NA"
+	)][string]$dmaManualId="NA",
+	[Parameter(
+		Mandatory=$False,
+		HelpMessage="The log file location"
+	)][string]$logLocation="$PSScriptRoot\dmaSqlServerHWSpecs.log"
 )
 
+Import-Module $PSScriptRoot\dmaCollectorCommonFunctions.psm1
+
 try {
-	Write-Host "Params: computer:$computerName, dma_src: $dmaSourceId, output:$outputPath"
+	WriteLog -logLocation $logLocation -logMessage "Fetching machine HW specs from computer:$computerName and storing it in output:$outputPath" -logOperation "FILE"
 
 	# Logical cores count.
 	$cores=(Get-WmiObject Win32_Processor -ComputerName $computerName | Measure-Object -Property NumberOfLogicalProcessors -Sum).Sum
@@ -75,8 +83,8 @@ try {
 	
 	# Writing to csv.
 	$csvData | Export-Csv -Path $outputPath -Delimiter "|" -NoTypeInformation
-	Write-Host "Success to retrieve information from $computerName."
+	WriteLog -logLocation $logLocation -logMessage "Successfully fetched machine HW specs of $computerName to output:$outputPath" -logOperation "FILE"	
 }
 catch {
-	Write-Host "Failed to retrieve hardware information from $computerName, skipping."
+	WriteLog -logLocation $logLocation -logMessage "ERROR - Failed fetching machine HW specs of $computerName" -logOperation "FILE"	
 }

--- a/scripts/collector/sqlserver/dmaSQLServerHWSpecs.ps1
+++ b/scripts/collector/sqlserver/dmaSQLServerHWSpecs.ps1
@@ -87,15 +87,8 @@ try {
 }
 catch {
 	WriteLog -logLocation $logLocation -logMessage "ERROR - Failed fetching machine HW specs of $computerName" -logOperation "FILE"	
-	# Empty CSV data.
-	$csvData = [PSCustomObject]@{
-		"pkey" = $null
-		"dma_source_id" = $null
-		"dma_manual_id" = $null
-		"computer_name" = $null
-		"cores" = $null
-		"memory_bytes" = $null
-	}
-	# Writing headers only to csv.
-	$csvData | Export-Csv -Path $outputPath -Delimiter "|" -NoTypeInformation -Encoding UTF8
+
+	# Writing Empty CSV File.
+	$headers = '"pkey"|"dma_source_id"|"dma_manual_id"|"computer_name"|"cores"|"memory_bytes"'
+	$headers | Out-File -FilePath $outputPath -Encoding UTF8
 }

--- a/scripts/collector/sqlserver/instanceReview.ps1
+++ b/scripts/collector/sqlserver/instanceReview.ps1
@@ -362,7 +362,7 @@ if ($ignorePerfmon -eq "true") {
 }
 
 ## Getting HW Specs.
-$computerSpecsFile = 'opdb' + '__' + 'DbComputerSpecs' + $outputFileSuffix
+$computerSpecsFile = 'opdb' + '__' + 'DbMachineSpecs' + $outputFileSuffix
 $dbCollectOut=$foldername + '/' + $computerSpecsFile
 WriteLog -logMessage "Getting HW Shape Info of $machinename"
 .\dmaSQLServerHWSpecs.ps1 -computerName $machinename -outputPath $dbCollectOut -pkey $pkey -dmaSourceId $dmaSourceId -dmaManualId $manualUniqueId

--- a/scripts/collector/sqlserver/instanceReview.ps1
+++ b/scripts/collector/sqlserver/instanceReview.ps1
@@ -361,6 +361,12 @@ if ($ignorePerfmon -eq "true") {
     }
 }
 
+## Getting HW Specs.
+$computerSpecsFile = 'opdb' + '__' + 'DbComputerSpecs' + $outputFileSuffix
+$dbCollectOut=$foldername + '/' + $computerSpecsFile
+WriteLog -logMessage "Getting HW Shape Info of $machinename"
+.\dmaSQLServerHWSpecs.ps1 -computerName $machinename -outputPath $dbCollectOut -pkey $pkey -dmaSourceId $dmaSourceId -dmaManualId $manualUniqueId
+
 WriteLog -logLocation $foldername\$logFile -logMessage "Remove special characters and UTF8 BOM from extracted files..." -logOperation "BOTH"
 foreach($file in Get-ChildItem -Path $foldername\*.csv) {
 	$inputFile = Split-Path -Leaf $file

--- a/scripts/collector/sqlserver/instanceReview.ps1
+++ b/scripts/collector/sqlserver/instanceReview.ps1
@@ -239,6 +239,7 @@ $dbServerFlags = 'opdb' + '__' + 'DbServerFlags' + $outputFileSuffix
 $dbServerConfig = 'opdb' + '__' + 'DbServerConfig' + $outputFileSuffix
 $dbServerDmvPerfmon = 'opdb' + '__' + 'DmvPerfmon' + $outputFileSuffix
 $manifestFile = 'opdb' + '__' + 'manifest' + $outputFileSuffix
+$computerSpecsFile = 'opdb' + '__' + 'DbMachineSpecs' + $outputFileSuffix
 
 $outputFileArray = @($compFileName,
                     $srvFileName,
@@ -257,7 +258,8 @@ $outputFileArray = @($compFileName,
                     $dbServerFlags,
                     $dbServerConfig,
                     $dbServerDmvPerfmon,
-                    $manifestFile)
+                    $manifestFile,
+                    $computerSpecsFile)
 
 WriteLog -logMessage "Checking directory path + output file name lengths for max length limitations..." -logOperation "MESSAGE"
 foreach ($directory in $outputFileArray) {
@@ -361,8 +363,7 @@ if ($ignorePerfmon -eq "true") {
     }
 }
 
-## Getting HW Specs.
-   $computerSpecsFile = 'opdb' + '__' + 'DbMachineSpecs' + $outputFileSuffix
+## Getting HW Specs.   
    $dbCollectOut=$foldername + '/' + $computerSpecsFile   
    WriteLog -logLocation $foldername\$logFile -logMessage "Retriving SQL Server HW Shape Info for Machine $machinename ..." -logOperation "FILE"
    .\dmaSQLServerHWSpecs.ps1 -computerName $machinename -outputPath $dbCollectOut -logLocation $foldername\$logFile -pkey $pkey -dmaSourceId $dmaSourceId -dmaManualId $manualUniqueId

--- a/scripts/collector/sqlserver/instanceReview.ps1
+++ b/scripts/collector/sqlserver/instanceReview.ps1
@@ -362,10 +362,10 @@ if ($ignorePerfmon -eq "true") {
 }
 
 ## Getting HW Specs.
-$computerSpecsFile = 'opdb' + '__' + 'DbMachineSpecs' + $outputFileSuffix
-$dbCollectOut=$foldername + '/' + $computerSpecsFile
-WriteLog -logMessage "Getting HW Shape Info of $machinename"
-.\dmaSQLServerHWSpecs.ps1 -computerName $machinename -outputPath $dbCollectOut -pkey $pkey -dmaSourceId $dmaSourceId -dmaManualId $manualUniqueId
+   $computerSpecsFile = 'opdb' + '__' + 'DbMachineSpecs' + $outputFileSuffix
+   $dbCollectOut=$foldername + '/' + $computerSpecsFile   
+   WriteLog -logLocation $foldername\$logFile -logMessage "Retriving SQL Server HW Shape Info for Machine $machinename ..." -logOperation "FILE"
+   .\dmaSQLServerHWSpecs.ps1 -computerName $machinename -outputPath $dbCollectOut -logLocation $foldername\$logFile -pkey $pkey -dmaSourceId $dmaSourceId -dmaManualId $manualUniqueId
 
 WriteLog -logLocation $foldername\$logFile -logMessage "Remove special characters and UTF8 BOM from extracted files..." -logOperation "BOTH"
 foreach($file in Get-ChildItem -Path $foldername\*.csv) {


### PR DESCRIPTION
dmaSQLServerHWSpecs.ps1 collects amount of cores and total memory capacity in bytes from the machineName
in SQL collect script.

I've tested it on 2 labs, it has a prerequisite of access of WMI from where the script is being run, if it fails it should only log a failure and not fail the collection script.

I've ran the `make build`
then copied the zip into a windows machine and ran it against another windows machine with MSSQL server

output csv:
```
"pkey"|"dma_source_id"|"dma_manual_id"|"computer_name"|"cores"|"memory_bytes"
"WIN-U6S28Q6HGOB_master_MSSQLSERVER_102923052805"|"WIN-U6S28Q6HGOB_33758EFA592E405990C30073089AD701_MSSQLSERVER"|"NA"|"WIN-U6S28Q6HGOB"|"4"|"8589934592"
```