### PR TITLE
Adding remote Windows params for WMI-GetObject

### DIFF
--- a/scripts/collector/sqlserver/README.txt
+++ b/scripts/collector/sqlserver/README.txt
@@ -159,6 +159,8 @@ Operating System Versions:
                 -database **Optional (Defaults to all user databases)
                 -collectionUserName **Required
                 -collectionUserPass **Optional (If not provided will be prompted)
+                -serverUserName **Optional (If not provided will attempt to use local credential)
+                -serverUserPass **Optional (If not provided will attempt to use local credential)
                 -ignorePerfmon **Optional (Defaults to "false" / Set to "true" to ignore perfmon collection)
                 -manualUniqueId **Optional (Defaults to "NA" - Gives the ability the user to tag their collection with a unique name)
 
@@ -167,6 +169,7 @@ Operating System Versions:
 
                 Example (default port): runAssessment.bat -serverName MS-SERVER1 -collectionUserName sa -collectionUserPass password123 -manualUniqueId [string]
                 Example (custom port): runAssessment.bat -serverName MS-SERVER1 -port 1435 -collectionUserName sa -collectionUserPass password123 -manualUniqueId [string]
+                Example (remote windows server with different user): runAssessment.bat -serverName MS-SERVER1 -port 1435 -collectionUserName sa -collectionUserPass password123 -serverUserName saUser -serverUserPass saPassword123 -manualUniqueId [string]
 
         For a Named Instance (single database):
             .\runAssessment.bat -serverName [servername\instanceName] -port [port number] -database [database name] -collectionUserName [collection user name] -collectionUserPass [collection user password] -manualUniqueId [string]

--- a/scripts/collector/sqlserver/instanceReview.ps1
+++ b/scripts/collector/sqlserver/instanceReview.ps1
@@ -28,6 +28,10 @@
     Collection username (required)
 .PARAMETER collectionUserPass
     Collection username password (required)
+.PARAMETER serverUserName
+    Remote login username with WMI GetObject Access (optional)
+.PARAMETER serverUserPass
+    Remote login password with WMI GetObject Access (optional)
 .PARAMETER ignorePerfmon
     Signals if the perfmon collection should be skipped (default:false) 
 .PARAMETER manualUniqueId
@@ -48,6 +52,8 @@ Param(
 [Parameter(Mandatory=$false)][string]$database="all",
 [Parameter(Mandatory=$false)][string]$collectionUserName,
 [Parameter(Mandatory=$false)][string]$collectionUserPass,
+[Parameter(Mandatory=$false)][string]$serverUserName=$null,
+[Parameter(Mandatory=$false)][string]$serverUserPass=$null,
 [Parameter(Mandatory=$false)][string]$ignorePerfmon="false",
 [Parameter(Mandatory=$false)][string]$manualUniqueId="NA"
 )
@@ -366,7 +372,7 @@ if ($ignorePerfmon -eq "true") {
 ## Getting HW Specs.   
    $dbCollectOut=$foldername + '/' + $computerSpecsFile   
    WriteLog -logLocation $foldername\$logFile -logMessage "Retriving SQL Server HW Shape Info for Machine $machinename ..." -logOperation "FILE"
-   .\dmaSQLServerHWSpecs.ps1 -computerName $machinename -outputPath $dbCollectOut -logLocation $foldername\$logFile -pkey $pkey -dmaSourceId $dmaSourceId -dmaManualId $manualUniqueId
+   .\dmaSQLServerHWSpecs.ps1 -computerName $machinename -outputPath $dbCollectOut -username $serverUserName -password $serverUserPass -logLocation $foldername\$logFile -pkey $pkey -dmaSourceId $dmaSourceId -dmaManualId $manualUniqueId
 
 WriteLog -logLocation $foldername\$logFile -logMessage "Remove special characters and UTF8 BOM from extracted files..." -logOperation "BOTH"
 foreach($file in Get-ChildItem -Path $foldername\*.csv) {

--- a/scripts/collector/sqlserver/runAssessment.bat
+++ b/scripts/collector/sqlserver/runAssessment.bat
@@ -41,6 +41,8 @@ if /i "%1" == "-port" set "port=%2"
 if /i "%1" == "-database" set "database=%2"
 if /i "%1" == "-collectionUserName" set "user=%2"
 if /i "%1" == "-collectionUserPass" set "pass=%2"
+if /i "%1" == "-serverUserName" set "serverUserName=%2"
+if /i "%1" == "-serverUserPass" set "serverUserPass=%2"
 if /i "%1" == "-ignorePerfmon" set "noPerfmon=%2"
 if /i "%1" == "-manualUniqueId" set "manualUniqueId=%2"
 
@@ -58,7 +60,7 @@ if not [%user%]==[] goto execWithCustomUser
 if [%serverName%]==[] goto raiseServerError
 if [%user%] == [] goto error
 
-PowerShell -nologo -NoProfile -ExecutionPolicy Bypass -File .\instanceReview.ps1 -serverName %serverName% -port %port% -database %database% -collectionUserName %user% -collectionUserPass %pass% -ignorePerfmon %noPerfmon% -manualUniqueId %manualUniqueId%
+PowerShell -nologo -NoProfile -ExecutionPolicy Bypass -File .\instanceReview.ps1 -serverName %serverName% -port %port% -database %database% -collectionUserName %user% -collectionUserPass %pass% -serverUserName %serverUserName% -serverUserPass %serverUserPass% -ignorePerfmon %noPerfmon% -manualUniqueId %manualUniqueId%
 
 if %errorlevel% == 1 goto exit
 goto done


### PR DESCRIPTION
optional param to runAssesment.bat:
-serverUserName
-serverUserPass

if entered, we will use them and build $credential and run Wmi-GetObject with "-Credential $crednetial"
otherwise we will send the commend to Wmi-GetObject without "-Credential <Creds>"