### PR TITLE
feat: `AIX` related fixes and manually limit `AWR` usage period

### DIFF
--- a/docs/user_guide/oracle/collection_scripts.md
+++ b/docs/user_guide/oracle/collection_scripts.md
@@ -83,6 +83,11 @@ Launch the collection script: (Note that the parameter names have changed from e
      --statsSrc              Required. Must be one of AWR, STATSPACK, NONE
  Performance statistics window
      --statsWindow           Optional. Number of days of performance stats to collect.  Must be one of 7, 30.  Default is 30.
+
+
+ NOTE: If using an Oracle auto-login wallet, specify the tns alias as the connection string:
+  Ex:
+    ./collect-data.sh --connectionStr /@mywalletalias --statsSrc AWR
 ```
 
 

--- a/docs/user_guide/oracle/collection_scripts.md
+++ b/docs/user_guide/oracle/collection_scripts.md
@@ -81,6 +81,8 @@ Launch the collection script: (Note that the parameter names have changed from e
     }
  Performance statistics source
      --statsSrc              Required. Must be one of AWR, STATSPACK, NONE
+ Performance statistics window
+     --statsWindow           Optional. Number of days of performance stats to collect.  Must be one of 7, 30.  Default is 30.
 ```
 
 
@@ -111,6 +113,13 @@ ex:
 ./collect-data.sh --connectionStr MyUser/MyPassword@//dbhost.company.com:1521/MyDbName.company.com --statsSrc STATSPACK
 or
 ./collect-data.sh --collectionUserName MyUser --collectionUserPass MyPassword --hostName dbhost.company.com --port 1521 --databaseService MyDbName.company.com --statsSrc STATSPACK
+
+
+If Statspack has less than 30 days of data, limit collection to the last 7 days using the paramter --statsWindow:
+
+./collect-data.sh --connectionStr MyUser/MyPassword@//dbhost.company.com:1521/MyDbName.company.com --statsSrc STATSPACK --statsWindow 7
+or
+./collect-data.sh --collectionUserName MyUser --collectionUserPass MyPassword --hostName dbhost.company.com --port 1521 --databaseService MyDbName.company.com --statsSrc STATSPACK --statsWindow 7
 ```
 
 Collections can be run as SYS if needed by setting ORACLE_SID and running on the database host:

--- a/scripts/collector/oracle/collect-data.sh
+++ b/scripts/collector/oracle/collect-data.sh
@@ -274,7 +274,7 @@ fi
 }
 
 
-function printUsage()
+function printUsage 
 {
 echo " Usage:"
 echo "  Parameters"

--- a/scripts/collector/oracle/collect-data.sh
+++ b/scripts/collector/oracle/collect-data.sh
@@ -34,7 +34,7 @@ SQL_DIR=${SCRIPT_DIR}/sql
 
 GREP=$(which grep)
 SED=$(which sed)
-MD5SUM=$(which md5sum)
+MD5SUM=$(which md5sum 2>/dev/null)
 MD5COL=1
 
 if [ "$(uname)" = "SunOS" ]

--- a/scripts/collector/oracle/collect-data.sh
+++ b/scripts/collector/oracle/collect-data.sh
@@ -176,6 +176,7 @@ done
 
 function compressOpFiles  {
 V_FILE_TAG=$1
+DBTYPE=$2
 V_ERR_TAG=""
 echo ""
 echo "Archiving output files with tag ${V_FILE_TAG}"
@@ -212,15 +213,14 @@ then
 fi
 
 # Skip creating the manifest file if the platform does not have MD5SUM installed
-if [ -f "$MD5SUM" ] ; then
-  for file in $(ls -1  opdb*${V_FILE_TAG}.csv opdb*${V_FILE_TAG}*.log opdb*${V_FILE_TAG}*.txt)
-  do
+for file in $(ls -1  opdb*${V_FILE_TAG}.csv opdb*${V_FILE_TAG}*.log opdb*${V_FILE_TAG}*.txt)
+do
+ if [ -f "$MD5SUM" ] ; then
    MD5=$(${MD5SUM} $file | cut -d ' ' -f ${MD5COL})
-   echo "${DBTYPE}|${MD5}|${file}"  >> opdb__manifest__${V_FILE_TAG}.txt
-  done
-else 
-  echo "Executable md5sum not found, skipping manifest file creation."
-fi
+ else MD5="N/A"
+ fi   
+ echo "${DBTYPE}|${MD5}|${file}"  >> opdb__manifest__${V_FILE_TAG}.txt
+done
 
 if [ ! "${ZIP}" = "" ]
 then
@@ -457,7 +457,7 @@ if [ $retval -eq 0 ]; then
       echo "Exiting...."
       exit 255
     fi
-    compressOpFiles $(echo ${V_TAG} | sed 's/.csv//g')
+    compressOpFiles $(echo ${V_TAG} | sed 's/.csv//g') $dbType
     retval=$?
     if [ $retval -ne 0 ]; then
       echo "!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!"

--- a/scripts/collector/oracle/collect-data.sh
+++ b/scripts/collector/oracle/collect-data.sh
@@ -211,11 +211,16 @@ then
   rm opdb__manifest__${V_FILE_TAG}.txt
 fi
 
-for file in $(ls -1  opdb*${V_FILE_TAG}.csv opdb*${V_FILE_TAG}*.log opdb*${V_FILE_TAG}*.txt)
-do
- MD5=$(${MD5SUM} $file | cut -d ' ' -f ${MD5COL})
- echo "${DBTYPE}|${MD5}|${file}"  >> opdb__manifest__${V_FILE_TAG}.txt
-done
+# Skip creating the manifest file if the platform does not have MD5SUM installed
+if [ -f "$MD5SUM" ] ; then
+  for file in $(ls -1  opdb*${V_FILE_TAG}.csv opdb*${V_FILE_TAG}*.log opdb*${V_FILE_TAG}*.txt)
+  do
+   MD5=$(${MD5SUM} $file | cut -d ' ' -f ${MD5COL})
+   echo "${DBTYPE}|${MD5}|${file}"  >> opdb__manifest__${V_FILE_TAG}.txt
+  done
+else 
+  echo "Executable md5sum not found, skipping manifest file creation."
+fi
 
 if [ ! "${ZIP}" = "" ]
 then

--- a/scripts/collector/oracle/sql/op_collect.sql
+++ b/scripts/collector/oracle/sql/op_collect.sql
@@ -21,6 +21,7 @@ DEFINE v_dodiagnostics=&3
 DEFINE v_tag=&4
 DEFINE outputdir=&5
 DEFINE v_manualUniqueId=&6
+DEFINE v_statsWindow=&7
 
 DEFINE EXTRACTSDIR=&SQLDIR/extracts
 DEFINE AWRDIR=&EXTRACTSDIR/awr

--- a/scripts/collector/oracle/sql/op_collect_init.sql
+++ b/scripts/collector/oracle/sql/op_collect_init.sql
@@ -20,7 +20,7 @@ Please ensure you have proper licensing. For more information consult Oracle Sup
 prompt Param1 = &1
 
 define version = '&1'
-define dtrange = 30
+define dtrange = &v_statsWindow
 define colspr = '|'
 
 @@op_set_sql_env.sql 

--- a/scripts/collector/oracle/sql/op_collect_init.sql
+++ b/scripts/collector/oracle/sql/op_collect_init.sql
@@ -344,6 +344,8 @@ DECLARE
   l_tab_name VARCHAR2(100) := '---';
   l_col_name VARCHAR2(100);
   the_sql VARCHAR2(1000) := '---';
+  table_does_not_exist EXCEPTION;
+  PRAGMA EXCEPTION_INIT (table_does_not_exist, -00942);
 BEGIN 
   :sp  := 'prompt_nostatspack.sql';
   IF '&v_dodiagnostics' = 'usediagnostics' THEN 
@@ -363,13 +365,17 @@ BEGIN
        END IF;
   END IF; 
   BEGIN
-    SELECT count(1) INTO cnt FROM user_tab_privs WHERE table_name = upper(l_tab_name);
-    IF cnt = 0 THEN
-      IF l_tab_name ='---' THEN
-        dbms_output.put_line('This user does not have SELECT privileges on DBA_HIST_SNAPSHOT or STATS$SNAPSHOT.  No performance data will be collected.');
-      ELSE
-        RAISE_APPLICATION_ERROR(-20002, 'This user does not have SELECT privileges on ' || l_tab_name || '.  Please ensure the grants_wrapper.sql script has been executed for this user.');
-      END IF;
+    IF l_tab_name = '---' THEN
+        dbms_output.put_line('No performance data will be collected.');
+    ELSE	
+      BEGIN
+        EXECUTE IMMEDIATE 'SELECT count(1) FROM ' || upper(l_tab_name) || ' WHERE rownum < 2' INTO cnt ;
+        IF cnt = 0 THEN
+            dbms_output.put_line('No data found in ' ||  upper(l_tab_name) || '.  No performance data will be collected.');
+        END IF;
+        EXCEPTION WHEN table_does_not_exist THEN
+          RAISE_APPLICATION_ERROR(-20002, 'This user does not have SELECT privileges on ' || upper(l_tab_name) || '.  Please ensure the grants_wrapper.sql script has been executed for this user.');
+      END;	
     END IF;
   END;
   IF (l_tab_name != '---' AND l_tab_name NOT LIKE 'ERROR%') THEN


### PR DESCRIPTION
This PR does the following Oracle changes:

- Add option limit `AWR` collection window of performance stats to 7 days.
- Use 'N/A' for md5 hash in manifest file if `md5sum` binary is not installed.
- Suppress error message if md5sum is not installed.
- Change method of checking user privileges.
- Remove parenthesis for ksh compatibility.
