### PR TITLE
feat: Add option to request user credentials when collecting HW specs (windows)

### DIFF
--- a/docs/user_guide/sqlserver/collection_scripts.md
+++ b/docs/user_guide/sqlserver/collection_scripts.md
@@ -191,6 +191,7 @@ The script will create a permon data set that will collect the above metrics at 
   - -collectionUserPass \*\*Required
   - -ignorePerfmon \*\*Optional (Defaults to "false" / Set to "true" to ignore perfmon collection)
   - -manualUniqueId \*\*Optional (Defaults to "NA" - Gives the ability the user to tag their collection with a unique name)
+  - -collectVMSpecs \*\*Optional switch. See [below](#collectvmspecs).
 
 To Execute the Collection:
 
@@ -233,6 +234,16 @@ To Execute the Collection:
           2. Collection scripts should be executed from an "Administrator Mode" command prompt
           3. When using a port to connect only provide the local host name
           4. The manualUniqueId can be used to give the collection a unique identifier specified by the customer
+
+##### CollectVMSpecs:
+To provide rightsizing information the script attempts to connect to the host VM using the current users credentials and collect hardware specs (number of CPUs/amount of memory).
+
+If the current user does not have sufficient permissions, it will skip this step. To manually input the correct credentials instead when this occurs, specify the `-collectVMSpecs` switch.
+  
+This is recommended if you plan to upload the results to the Migration Center.
+
+        Example: runAssessment.bat -serverName MS-SERVER1 -collectionUserName sa -collectionUserPass password123 -manualUniqueId [string] -collectVMSpecs
+
 
 ---
 

--- a/scripts/collector/sqlserver/README.txt
+++ b/scripts/collector/sqlserver/README.txt
@@ -163,6 +163,7 @@ Operating System Versions:
                 -collectionUserPass **Optional (If not provided will be prompted)
                 -ignorePerfmon **Optional (Defaults to "false" / Set to "true" to ignore perfmon collection)
                 -manualUniqueId **Optional (Defaults to "NA" - Gives the ability the user to tag their collection with a unique name)
+                -collectVMSpecs **Optional switch. See below.
 
         For a Named Instance (all databases):
             .\runAssessment.bat -serverName [servername\instanceName] -port [port number] -collectionUserName [collection user name] -collectionUserPass [collection user password] -manualUniqueId [string]
@@ -201,6 +202,13 @@ Operating System Versions:
             2) Collection scripts should be executed from an "Administrator Mode" command prompt
             3) When using a port to connect only provide the local host name
             4) The manualUniqueId can be used to give the collection a unique identifier specified by the customer
+
+        CollectVMSpecs:
+            To provide rightsizing information the script attempts to connect to the host VM using the current users credentials and collect hardware specs (number of CPUs/amount of memory).
+            If the current user does not have sufficient permissions, it will skip this step. To manually input the correct credentials instead when this occurs, specify the -collectVMSpecs switch.
+            This is recommended if you plan to upload the results to the Migration Center.
+
+            Example: runAssessment.bat -serverName MS-SERVER1 -collectionUserName sa -collectionUserPass password123 -manualUniqueId [string] -collectVMSpecs
 
 4. Results
 ----------

--- a/scripts/collector/sqlserver/dmaSQLServerHWSpecs.ps1
+++ b/scripts/collector/sqlserver/dmaSQLServerHWSpecs.ps1
@@ -74,8 +74,8 @@ $params = @{
 if ($requestCreds) {
 	try {
 		Get-WmiObject Win32_Processor -ComputerName $computerName > $null
-	}
- catch {
+	} 
+	catch {
 		if ($_.Exception.GetType().FullName -eq "System.UnauthorizedAccessException") {
 			$params.Credential = $host.ui.PromptForCredential(
 				"Credentials for $computerName", 
@@ -96,7 +96,6 @@ $csvData = [PSCustomObject]@{
 	"LogicalCpuCount"    = $null
 	"TotalOSMemoryBytes" = $null
 	"TotalOSMemoryMB"    = $null
-
 }
 
 try {

--- a/scripts/collector/sqlserver/dmaSQLServerHWSpecs.ps1
+++ b/scripts/collector/sqlserver/dmaSQLServerHWSpecs.ps1
@@ -111,7 +111,7 @@ try {
 	$csvData.TotalOSMemoryBytes = (Get-WmiObject Win32_PhysicalMemory @params | Measure-Object -Property Capacity -Sum).Sum
 
 	# Total memory in MB.
-	$csvData.TotalOSMemoryMB = [Math]::Floor([decimal]($csvData.TotalOSMemoryBytes / 1000000))
+	$csvData.TotalOSMemoryMB = [Math]::Floor([decimal]($csvData.TotalOSMemoryBytes / 1048576))
 	
 	# Writing to csv.
 	$csvData | Export-Csv -Path $outputPath -Delimiter "|" -NoTypeInformation -Encoding UTF8

--- a/scripts/collector/sqlserver/runAssessment.bat
+++ b/scripts/collector/sqlserver/runAssessment.bat
@@ -25,6 +25,7 @@ set helpExample=Example (default port): runAssessment.bat -serverName MS-SERVER1
 set helpExamplePort=Example (specified port): runAssessment.bat -serverName MS-SERVER1 -port 1436 -collectionUserName sa -collectionUserPass password123 -ignorePerfmon [true/false] -manualUniqueId mySQLServerDB1
 set helpExampleDatabase=Example (default port / single database): runAssessment.bat -serverName MS-SERVER1\SQL2019 -database AdventureWorks2019 -collectionUserName sa -collectionUserPass password123 -ignorePerfmon [true/false] -manualUniqueId mySQLServerDB1
 set helpExampleDatabasePort=Example (specified port / single database): runAssessment.bat -serverName MS-SERVER1 -port 1436 -database AdventureWorks2019 -collectionUserName sa -collectionUserPass password123 -ignorePerfmon [true/false] -manualUniqueId mySQLServerDB1
+set collectVMSpecs=
 
 if [%1]==[] (
     goto helpOperation
@@ -43,6 +44,7 @@ if /i "%1" == "-collectionUserName" set "user=%2"
 if /i "%1" == "-collectionUserPass" set "pass=%2"
 if /i "%1" == "-ignorePerfmon" set "noPerfmon=%2"
 if /i "%1" == "-manualUniqueId" set "manualUniqueId=%2"
+if /i "%1" == "-collectVMSpecs" set "collectVMSpecs=true"
 
 shift
 goto :loop
@@ -58,7 +60,13 @@ if not [%user%]==[] goto execWithCustomUser
 if [%serverName%]==[] goto raiseServerError
 if [%user%] == [] goto error
 
-PowerShell -nologo -NoProfile -ExecutionPolicy Bypass -File .\instanceReview.ps1 -serverName %serverName% -port %port% -database %database% -collectionUserName %user% -collectionUserPass %pass% -ignorePerfmon %noPerfmon% -manualUniqueId %manualUniqueId%
+SET "command=PowerShell -nologo -NoProfile -ExecutionPolicy Bypass -File .\instanceReview.ps1 -serverName %serverName% -port %port% -database %database% -collectionUserName %user% -collectionUserPass %pass% -ignorePerfmon %noPerfmon% -manualUniqueId %manualUniqueId%"
+
+if "%collectVMSpecs%"=="" (
+	CALL %command% 
+) ELSE (
+	CALL %command% -collectVMSpecs
+)
 
 if %errorlevel% == 1 goto exit
 goto done

--- a/scripts/collector/sqlserver/runAssessment.bat
+++ b/scripts/collector/sqlserver/runAssessment.bat
@@ -20,11 +20,12 @@ set pass=false
 set manualUniqueId="NA"
 set database=all
 set noPerfmon=false
-set helpMessage=Usage: runAssessment.bat -serverName [servername] -port [port number] -database [database name] -collectionUserName [username] -collectionUserPass [password] -ignorePerfmon [true/false] -manualUniqueId [unique tag to identify collection]
+set helpMessage=Usage: runAssessment.bat -serverName [servername] -port [port number] -database [database name] -collectionUserName [username] -collectionUserPass [password] -ignorePerfmon [true/false] -manualUniqueId [unique tag to identify collection] [-collectVMSpecs]
 set helpExample=Example (default port): runAssessment.bat -serverName MS-SERVER1\SQL2019 -collectionUserName sa -collectionUserPass password123 -ignorePerfmon [true/false] -manualUniqueId mySQLServerDB1
 set helpExamplePort=Example (specified port): runAssessment.bat -serverName MS-SERVER1 -port 1436 -collectionUserName sa -collectionUserPass password123 -ignorePerfmon [true/false] -manualUniqueId mySQLServerDB1
 set helpExampleDatabase=Example (default port / single database): runAssessment.bat -serverName MS-SERVER1\SQL2019 -database AdventureWorks2019 -collectionUserName sa -collectionUserPass password123 -ignorePerfmon [true/false] -manualUniqueId mySQLServerDB1
 set helpExampleDatabasePort=Example (specified port / single database): runAssessment.bat -serverName MS-SERVER1 -port 1436 -database AdventureWorks2019 -collectionUserName sa -collectionUserPass password123 -ignorePerfmon [true/false] -manualUniqueId mySQLServerDB1
+set helpExampleCollectVMSpecs=Example (collect specs from host VM): runAssessment.bat -serverName MS-SERVER1\SQL2019 -collectionUserName sa -collectionUserPass password123 -ignorePerfmon [true/false] -manualUniqueId mySQLServerDB1 -collectVMSpecs
 set collectVMSpecs=
 
 if [%1]==[] (
@@ -98,6 +99,8 @@ echo:
 echo %helpExampleDatabase%
 echo:
 echo %helpExampleDatabasePort%
+echo:
+echo %helpExampleCollectVMSpecs%
 echo:
 goto done
 


### PR DESCRIPTION
We first try to collect using current user credentials. If that fails, and the user has set the -collectVMSpecs flag, we request the credentials from the user via a pop up prompt:

![image](https://github.com/GoogleCloudPlatform/database-assessment/assets/29174528/615d3168-0f25-436e-aa72-d753be698571)

We also slightly modify the existing script to write machine name to csv even on failure.