### PR TITLE
feat: adds conformed `VERSION_NUM` to `config.sql`

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -166,3 +166,5 @@ scripts/collector/oracle/privs.sql
 scripts/collector/oracle/VERSION.txt
 scripts/collector/sqlserver/output/
 scripts/collector/oracle/login.sql
+
+node_modules

--- a/scripts/collector/mysql/sql/config.sql
+++ b/scripts/collector/mysql/sql/config.sql
@@ -233,6 +233,11 @@ calculated_metrics as (
     select 'FIREWALL_PLUGIN' as variable_name,
         p.firewall_plugin_enabled as variable_value
     from all_plugins p
+    union
+    select 'VERSION_NUM' as variable_name,
+        regexp_substr(gv.variable_value,'[0-9]+\.[0-9]+\.[0-9]+') as variable_value 
+    from performance_schema.global_variables gv
+    where gv.variable_name = 'VERSION'
 ),
 src as (
     select 'ALL_VARIABLES' as variable_category,


### PR DESCRIPTION
This PR adds a well formed `VERSION_NUM` row to the `config` file export.

This trims the trailing text that is often found when executing `select version()`