### PR TITLE
chore: adds hashes to release

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -38,6 +38,7 @@ jobs:
         with:
           hash-type: sha256
           file-name: hashes.txt
+          get-assets: true
       - uses: actions/upload-artifact@v2
         with:
           name: Upload Release Hashes

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -34,3 +34,11 @@ jobs:
         with:
           upload_url: ${{ github.event.release.upload_url }}
           asset_path: dist/db-migration-assessment-collection-scripts-postgres.zip
+      - uses: MCJack123/ghaction-generate-release-hashes@v3
+        with:
+          hash-type: sha256
+          file-name: hashes.txt
+      - uses: actions/upload-artifact@v2
+        with:
+          name: Upload Release Hashes
+          path: hashes.txt


### PR DESCRIPTION
This PR adds an file called `hashes.txt` to each release.  This file contains the `SHA256` checksums for the files at the time they were packaged.