### PR TITLE
feat: remove `cte` expressions for older `mysql` support

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -18,6 +18,17 @@ services:
       MYSQL_DATABASE: db
       MYSQL_ROOT_HOST: "%"
       LANG: C.UTF-8
+  mysql5:
+    image: mysql:5.7
+    ports:
+      - "3361:3306" # use a non-standard port here
+    environment:
+      MYSQL_ROOT_PASSWORD: super-secret
+      MYSQL_PASSWORD: super-secret
+      MYSQL_USER: app
+      MYSQL_DATABASE: db
+      MYSQL_ROOT_HOST: "%"
+      LANG: C.UTF-8
   oracle18c:
     image: gvenzl/oracle-xe:18-slim-faststart
     ports:

--- a/scripts/collector/mysql/sql/config.sql
+++ b/scripts/collector/mysql/sql/config.sql
@@ -559,7 +559,7 @@ from (
                     ) p
                 union
                 select 'VERSION_NUM' as variable_name,
-                    regexp_substr(gv.variable_value, '[0-9]+\.[0-9]+\.[0-9]+') as variable_value
+                    gv.variable_value as variable_value
                 from performance_schema.global_variables gv
                 where gv.variable_name = 'VERSION'
             ) calculated_metrics

--- a/scripts/collector/mysql/sql/config.sql
+++ b/scripts/collector/mysql/sql/config.sql
@@ -1,264 +1,566 @@
-with global_status as (
-    select upper(variable_name) as variable_name,
-        variable_value
-    from performance_schema.global_status a
-    where a.variable_name not in ('FT_BOOLEAN_SYNTAX')
-        and a.variable_name not like '%PUBLIC_KEY'
-        and a.variable_name not like '%PRIVATE_KEY'
-),
-all_vars as (
-    select variable_name,
-        variable_value
-    from (
-            select upper(variable_name) as variable_name,
-                variable_value
-            from performance_schema.global_variables
-            union
-            select upper(variable_name),
-                variable_value
-            from performance_schema.session_variables
-            where variable_name not in (
-                    select variable_name
-                    from performance_schema.global_variables
-                )
-        ) a
-    where a.variable_name not in ('FT_BOOLEAN_SYNTAX')
-        and a.variable_name not like '%PUBLIC_KEY'
-        and a.variable_name not like '%PRIVATE_KEY'
-),
-all_plugins as (
-    select if(agg.mysqlx_plugin > 0, 1, 0) as mysqlx_plugin_enabled,
-        if(agg.memcached_plugin > 0, 1, 0) as memcached_plugin_enabled,
-        if(agg.clone_plugin > 0, 1, 0) as clone_plugin_enabled,
-        if(agg.keyring_plugin > 0, 1, 0) as keyring_plugin_enabled,
-        if(agg.validate_password_plugin > 0, 1, 0) as validate_password_plugin_enabled,
-        if(agg.thread_pool_plugin > 0, 1, 0) as thread_pool_plugin_enabled,
-        if(agg.firewall_plugin > 0, 1, 0) as firewall_plugin_enabled
-    from (
-            select sum(
-                    if(
-                        upper(p.plugin_name) like '%MYSQLX%',
-                        1,
-                        0
-                    )
-                ) as mysqlx_plugin,
-                sum(
-                    if(
-                        upper(p.plugin_name) like '%MEMCACHED%',
-                        1,
-                        0
-                    )
-                ) as memcached_plugin,
-                sum(
-                    if(
-                        upper(p.plugin_name) like '%CLONE%',
-                        1,
-                        0
-                    )
-                ) as clone_plugin,
-                sum(
-                    if(
-                        upper(p.plugin_name) like '%KEYRING%',
-                        1,
-                        0
-                    )
-                ) as keyring_plugin,
-                sum(
-                    if(
-                        upper(p.plugin_name) like '%VALIDATE_PASSWORD%',
-                        1,
-                        0
-                    )
-                ) as validate_password_plugin,
-                sum(
-                    if(
-                        upper(p.plugin_name) like '%THREAD_POOL%',
-                        1,
-                        0
-                    )
-                ) as thread_pool_plugin,
-                sum(
-                    if(
-                        upper(p.plugin_name) like '%FIREWALL%',
-                        1,
-                        0
-                    )
-                ) as firewall_plugin
-            from (
-                    select p.plugin_name as plugin_name,
-                        p.PLUGIN_STATUS
-                    from information_schema.PLUGINS p
-                ) p
-        ) agg
-),
-data_summary as (
-    select table_schema,
-        count(table_name) as total_table_count,
-        sum(if(upper(table_engine) = 'INNODB', 1, 0)) as innodb_table_count,
-        sum(has_primary_key) as total_tables_with_primary_key,
-        sum(if(has_primary_key = 0, 1, 0)) as total_tables_without_primary_key,
-        sum(if(upper(table_engine) != 'INNODB', 1, 0)) as non_innodb_table_count,
-        sum(table_rows) as total_row_count,
-        sum(
-            if(upper(table_engine) = 'INNODB', table_rows, 0)
-        ) as innodb_table_row_count,
-        sum(
-            if(upper(table_engine) != 'INNODB', table_rows, 0)
-        ) as non_innodb_table_row_count,
-        sum(data_length) as total_data_size_bytes,
-        sum(
-            if(upper(table_engine) = 'INNODB', data_length, 0)
-        ) as innodb_data_size_bytes,
-        sum(
-            if(upper(table_engine) != 'INNODB', data_length, 0)
-        ) as non_innodb_data_size_bytes,
-        sum(index_length) as total_index_size_bytes,
-        sum(
-            if(upper(table_engine) = 'INNODB', index_length, 0)
-        ) as innodb_index_size_bytes,
-        sum(
-            if(upper(table_engine) != 'INNODB', index_length, 0)
-        ) as non_innodb_index_size_bytes,
-        sum(total_length) as total_size_bytes,
-        sum(
-            if(upper(table_engine) = 'INNODB', total_length, 0)
-        ) as innodb_total_size_bytes,
-        sum(
-            if(upper(table_engine) != 'INNODB', total_length, 0)
-        ) as non_innodb_total_size_bytes
-    from (
-            select t.table_schema as table_schema,
-                t.table_name as table_name,
-                t.table_rows as table_rows,
-                t.DATA_LENGTH as DATA_LENGTH,
-                t.INDEX_LENGTH as INDEX_LENGTH,
-                t.DATA_LENGTH + t.INDEX_LENGTH as total_length,
-                t.ROW_FORMAT as row_format,
-                t.TABLE_TYPE as table_type,
-                t.ENGINE as table_engine,
-                if(pks.table_name is not null, 1, 0) as has_primary_key
-            from information_schema.TABLES t
-                left join (
-                    select table_schema,
-                        TABLE_NAME
-                    from information_schema.statistics
-                    where table_schema not in (
-                            'mysql',
-                            'information_schema',
-                            'performance_schema',
-                            'sys'
-                        )
-                    group by table_schema,
-                        TABLE_NAME,
-                        index_name
-                    having SUM(
-                            if(
-                                non_unique = 0
-                                and NULLABLE != 'YES',
-                                1,
-                                0
-                            )
-                        ) = count(*)
-                ) pks on (
-                    t.table_schema = pks.table_schema
-                    and t.TABLE_NAME = pks.TABLE_NAME
-                )
-            where t.table_schema not in (
-                    'mysql',
-                    'information_schema',
-                    'performance_schema',
-                    'sys'
-                )
-        ) user_tables
-    group by user_tables.table_schema
-),
-calculated_metrics as (
-    select 'IS_MARIADB' as variable_name,
-        if(upper(gv.variable_value) like '%MARIADB%', 1, 0) as variable_value
-    from performance_schema.global_variables gv
-    where gv.variable_name = 'VERSION'
-    union
-    select 'TABLE_SIZE' as variable_name,
-        total_data_size_bytes as variable_value
-    from data_summary
-    union
-    select 'TABLE_NO_INNODB_SIZE' as variable_name,
-        non_innodb_data_size_bytes as variable_value
-    from data_summary
-    union
-    select 'TABLE_INNODB_SIZE' as variable_name,
-        innodb_data_size_bytes as variable_value
-    from data_summary
-    union
-    select 'TABLE_COUNT' as variable_name,
-        total_table_count as variable_value
-    from data_summary
-    union
-    select 'TABLE_NO_INNODB_COUNT' as variable_name,
-        non_innodb_table_count as variable_value
-    from data_summary
-    union
-    select 'TABLE_INNODB_COUNT' as variable_name,
-        innodb_table_count as variable_value
-    from data_summary
-    union
-    select 'TABLE_NO_PK_COUNT' as variable_name,
-        total_tables_without_primary_key as variable_value
-    from data_summary
-    union
-    select 'MYSQLX_PLUGIN' as variable_name,
-        p.mysqlx_plugin_enabled as variable_value
-    from all_plugins p
-    union
-    select 'MEMCACHED_PLUGIN' as variable_name,
-        p.memcached_plugin_enabled as variable_value
-    from all_plugins p
-    union
-    select 'CLONE_PLUGIN' as variable_name,
-        p.clone_plugin_enabled as variable_value
-    from all_plugins p
-    union
-    select 'KEYRING_PLUGIN' as variable_name,
-        p.keyring_plugin_enabled as variable_value
-    from all_plugins p
-    union
-    select 'VALIDATE_PASSWORD_PLUGIN' as variable_name,
-        p.validate_password_plugin_enabled as variable_value
-    from all_plugins p
-    union
-    select 'THREAD_POOL_PLUGIN' as variable_name,
-        p.thread_pool_plugin_enabled as variable_value
-    from all_plugins p
-    union
-    select 'FIREWALL_PLUGIN' as variable_name,
-        p.firewall_plugin_enabled as variable_value
-    from all_plugins p
-    union
-    select 'VERSION_NUM' as variable_name,
-        regexp_substr(gv.variable_value,'[0-9]+\.[0-9]+\.[0-9]+') as variable_value 
-    from performance_schema.global_variables gv
-    where gv.variable_name = 'VERSION'
-),
-src as (
-    select 'ALL_VARIABLES' as variable_category,
-        variable_name,
-        variable_value
-    from all_vars
-    union
-    select 'GLOBAL_STATUS' as variable_category,
-        variable_name,
-        variable_value
-    from global_status
-    union
-    select 'CALCULATED_METRIC' as variable_category,
-        variable_name,
-        variable_value
-    from calculated_metrics
-)
 select distinct concat(char(34), @PKEY, char(34)) as pkey,
     concat(char(34), @DMA_SOURCE_ID, char(34)) as dma_source_id,
     concat(char(34), @DMA_MANUAL_ID, char(34)) as dma_manual_id,
     concat(char(34), src.variable_category, char(34)) as variable_category,
     concat(char(34), src.variable_name, char(34)) as variable_name,
     concat(char(34), src.variable_value, char(34)) as variable_value
-from src;
+from (
+        select 'ALL_VARIABLES' as variable_category,
+            variable_name,
+            variable_value
+        from (
+                select variable_name,
+                    variable_value
+                from (
+                        select upper(variable_name) as variable_name,
+                            variable_value
+                        from performance_schema.global_variables
+                        union
+                        select upper(variable_name),
+                            variable_value
+                        from performance_schema.session_variables
+                        where variable_name not in (
+                                select variable_name
+                                from performance_schema.global_variables
+                            )
+                    ) a
+                where a.variable_name not in ('FT_BOOLEAN_SYNTAX')
+                    and a.variable_name not like '%PUBLIC_KEY'
+                    and a.variable_name not like '%PRIVATE_KEY'
+            ) all_vars
+        union
+        select 'GLOBAL_STATUS' as variable_category,
+            variable_name,
+            variable_value
+        from (
+                select upper(variable_name) as variable_name,
+                    variable_value
+                from performance_schema.global_status a
+                where a.variable_name not in ('FT_BOOLEAN_SYNTAX')
+                    and a.variable_name not like '%PUBLIC_KEY'
+                    and a.variable_name not like '%PRIVATE_KEY'
+            ) global_status
+        union
+        select 'CALCULATED_METRIC' as variable_category,
+            variable_name,
+            variable_value
+        from (
+                select 'IS_MARIADB' as variable_name,
+                    if(upper(gv.variable_value) like '%MARIADB%', 1, 0) as variable_value
+                from performance_schema.global_variables gv
+                where gv.variable_name = 'VERSION'
+                union
+                select 'TABLE_SIZE' as variable_name,
+                    total_data_size_bytes as variable_value
+                from (
+                        select table_schema,
+                            sum(data_length) as total_data_size_bytes
+                        from (
+                                select t.table_schema as table_schema,
+                                    t.table_name as table_name,
+                                    t.table_rows as table_rows,
+                                    t.DATA_LENGTH as DATA_LENGTH,
+                                    t.INDEX_LENGTH as INDEX_LENGTH,
+                                    t.DATA_LENGTH + t.INDEX_LENGTH as total_length,
+                                    t.ROW_FORMAT as row_format,
+                                    t.TABLE_TYPE as table_type,
+                                    t.ENGINE as table_engine,
+                                    if(pks.table_name is not null, 1, 0) as has_primary_key
+                                from information_schema.TABLES t
+                                    left join (
+                                        select table_schema,
+                                            TABLE_NAME
+                                        from information_schema.statistics
+                                        where table_schema not in (
+                                                'mysql',
+                                                'information_schema',
+                                                'performance_schema',
+                                                'sys'
+                                            )
+                                        group by table_schema,
+                                            TABLE_NAME,
+                                            index_name
+                                        having SUM(
+                                                if(
+                                                    non_unique = 0
+                                                    and NULLABLE != 'YES',
+                                                    1,
+                                                    0
+                                                )
+                                            ) = count(*)
+                                    ) pks on (
+                                        t.table_schema = pks.table_schema
+                                        and t.TABLE_NAME = pks.TABLE_NAME
+                                    )
+                                where t.table_schema not in (
+                                        'mysql',
+                                        'information_schema',
+                                        'performance_schema',
+                                        'sys'
+                                    )
+                            ) user_tables
+                        group by user_tables.table_schema
+                    ) data_summary
+                union
+                select 'TABLE_NO_INNODB_SIZE' as variable_name,
+                    non_innodb_data_size_bytes as variable_value
+                from (
+                        select table_schema,
+                            sum(
+                                if(upper(table_engine) != 'INNODB', data_length, 0)
+                            ) as non_innodb_data_size_bytes
+                        from (
+                                select t.table_schema as table_schema,
+                                    t.table_name as table_name,
+                                    t.table_rows as table_rows,
+                                    t.DATA_LENGTH as DATA_LENGTH,
+                                    t.INDEX_LENGTH as INDEX_LENGTH,
+                                    t.DATA_LENGTH + t.INDEX_LENGTH as total_length,
+                                    t.ROW_FORMAT as row_format,
+                                    t.TABLE_TYPE as table_type,
+                                    t.ENGINE as table_engine,
+                                    if(pks.table_name is not null, 1, 0) as has_primary_key
+                                from information_schema.TABLES t
+                                    left join (
+                                        select table_schema,
+                                            TABLE_NAME
+                                        from information_schema.statistics
+                                        where table_schema not in (
+                                                'mysql',
+                                                'information_schema',
+                                                'performance_schema',
+                                                'sys'
+                                            )
+                                        group by table_schema,
+                                            TABLE_NAME,
+                                            index_name
+                                        having SUM(
+                                                if(
+                                                    non_unique = 0
+                                                    and NULLABLE != 'YES',
+                                                    1,
+                                                    0
+                                                )
+                                            ) = count(*)
+                                    ) pks on (
+                                        t.table_schema = pks.table_schema
+                                        and t.TABLE_NAME = pks.TABLE_NAME
+                                    )
+                                where t.table_schema not in (
+                                        'mysql',
+                                        'information_schema',
+                                        'performance_schema',
+                                        'sys'
+                                    )
+                            ) user_tables
+                        group by user_tables.table_schema
+                    ) data_summary
+                union
+                select 'TABLE_INNODB_SIZE' as variable_name,
+                    innodb_data_size_bytes as variable_value
+                from (
+                        select table_schema,
+                            sum(
+                                if(upper(table_engine) = 'INNODB', data_length, 0)
+                            ) as innodb_data_size_bytes
+                        from (
+                                select t.table_schema as table_schema,
+                                    t.table_name as table_name,
+                                    t.table_rows as table_rows,
+                                    t.DATA_LENGTH as DATA_LENGTH,
+                                    t.INDEX_LENGTH as INDEX_LENGTH,
+                                    t.DATA_LENGTH + t.INDEX_LENGTH as total_length,
+                                    t.ROW_FORMAT as row_format,
+                                    t.TABLE_TYPE as table_type,
+                                    t.ENGINE as table_engine,
+                                    if(pks.table_name is not null, 1, 0) as has_primary_key
+                                from information_schema.TABLES t
+                                    left join (
+                                        select table_schema,
+                                            TABLE_NAME
+                                        from information_schema.statistics
+                                        where table_schema not in (
+                                                'mysql',
+                                                'information_schema',
+                                                'performance_schema',
+                                                'sys'
+                                            )
+                                        group by table_schema,
+                                            TABLE_NAME,
+                                            index_name
+                                        having SUM(
+                                                if(
+                                                    non_unique = 0
+                                                    and NULLABLE != 'YES',
+                                                    1,
+                                                    0
+                                                )
+                                            ) = count(*)
+                                    ) pks on (
+                                        t.table_schema = pks.table_schema
+                                        and t.TABLE_NAME = pks.TABLE_NAME
+                                    )
+                                where t.table_schema not in (
+                                        'mysql',
+                                        'information_schema',
+                                        'performance_schema',
+                                        'sys'
+                                    )
+                            ) user_tables
+                        group by user_tables.table_schema
+                    ) data_summary
+                union
+                select 'TABLE_COUNT' as variable_name,
+                    total_table_count as variable_value
+                from (
+                        select table_schema,
+                            count(table_name) as total_table_count
+                        from (
+                                select t.table_schema as table_schema,
+                                    t.table_name as table_name,
+                                    t.table_rows as table_rows,
+                                    t.DATA_LENGTH as DATA_LENGTH,
+                                    t.INDEX_LENGTH as INDEX_LENGTH,
+                                    t.DATA_LENGTH + t.INDEX_LENGTH as total_length,
+                                    t.ROW_FORMAT as row_format,
+                                    t.TABLE_TYPE as table_type,
+                                    t.ENGINE as table_engine,
+                                    if(pks.table_name is not null, 1, 0) as has_primary_key
+                                from information_schema.TABLES t
+                                    left join (
+                                        select table_schema,
+                                            TABLE_NAME
+                                        from information_schema.statistics
+                                        where table_schema not in (
+                                                'mysql',
+                                                'information_schema',
+                                                'performance_schema',
+                                                'sys'
+                                            )
+                                        group by table_schema,
+                                            TABLE_NAME,
+                                            index_name
+                                        having SUM(
+                                                if(
+                                                    non_unique = 0
+                                                    and NULLABLE != 'YES',
+                                                    1,
+                                                    0
+                                                )
+                                            ) = count(*)
+                                    ) pks on (
+                                        t.table_schema = pks.table_schema
+                                        and t.TABLE_NAME = pks.TABLE_NAME
+                                    )
+                                where t.table_schema not in (
+                                        'mysql',
+                                        'information_schema',
+                                        'performance_schema',
+                                        'sys'
+                                    )
+                            ) user_tables
+                        group by user_tables.table_schema
+                    ) data_summary
+                union
+                select 'TABLE_NO_INNODB_COUNT' as variable_name,
+                    non_innodb_table_count as variable_value
+                from (
+                        select table_schema,
+                            sum(if(upper(table_engine) != 'INNODB', 1, 0)) as non_innodb_table_count
+                        from (
+                                select t.table_schema as table_schema,
+                                    t.table_name as table_name,
+                                    t.table_rows as table_rows,
+                                    t.DATA_LENGTH as DATA_LENGTH,
+                                    t.INDEX_LENGTH as INDEX_LENGTH,
+                                    t.DATA_LENGTH + t.INDEX_LENGTH as total_length,
+                                    t.ROW_FORMAT as row_format,
+                                    t.TABLE_TYPE as table_type,
+                                    t.ENGINE as table_engine,
+                                    if(pks.table_name is not null, 1, 0) as has_primary_key
+                                from information_schema.TABLES t
+                                    left join (
+                                        select table_schema,
+                                            TABLE_NAME
+                                        from information_schema.statistics
+                                        where table_schema not in (
+                                                'mysql',
+                                                'information_schema',
+                                                'performance_schema',
+                                                'sys'
+                                            )
+                                        group by table_schema,
+                                            TABLE_NAME,
+                                            index_name
+                                        having SUM(
+                                                if(
+                                                    non_unique = 0
+                                                    and NULLABLE != 'YES',
+                                                    1,
+                                                    0
+                                                )
+                                            ) = count(*)
+                                    ) pks on (
+                                        t.table_schema = pks.table_schema
+                                        and t.TABLE_NAME = pks.TABLE_NAME
+                                    )
+                                where t.table_schema not in (
+                                        'mysql',
+                                        'information_schema',
+                                        'performance_schema',
+                                        'sys'
+                                    )
+                            ) user_tables
+                        group by user_tables.table_schema
+                    ) data_summary
+                union
+                select 'TABLE_INNODB_COUNT' as variable_name,
+                    innodb_table_count as variable_value
+                from (
+                        select table_schema,
+                            sum(if(upper(table_engine) = 'INNODB', 1, 0)) as innodb_table_count
+                        from (
+                                select t.table_schema as table_schema,
+                                    t.table_name as table_name,
+                                    t.table_rows as table_rows,
+                                    t.DATA_LENGTH as DATA_LENGTH,
+                                    t.INDEX_LENGTH as INDEX_LENGTH,
+                                    t.DATA_LENGTH + t.INDEX_LENGTH as total_length,
+                                    t.ROW_FORMAT as row_format,
+                                    t.TABLE_TYPE as table_type,
+                                    t.ENGINE as table_engine,
+                                    if(pks.table_name is not null, 1, 0) as has_primary_key
+                                from information_schema.TABLES t
+                                    left join (
+                                        select table_schema,
+                                            TABLE_NAME
+                                        from information_schema.statistics
+                                        where table_schema not in (
+                                                'mysql',
+                                                'information_schema',
+                                                'performance_schema',
+                                                'sys'
+                                            )
+                                        group by table_schema,
+                                            TABLE_NAME,
+                                            index_name
+                                        having SUM(
+                                                if(
+                                                    non_unique = 0
+                                                    and NULLABLE != 'YES',
+                                                    1,
+                                                    0
+                                                )
+                                            ) = count(*)
+                                    ) pks on (
+                                        t.table_schema = pks.table_schema
+                                        and t.TABLE_NAME = pks.TABLE_NAME
+                                    )
+                                where t.table_schema not in (
+                                        'mysql',
+                                        'information_schema',
+                                        'performance_schema',
+                                        'sys'
+                                    )
+                            ) user_tables
+                        group by user_tables.table_schema
+                    ) data_summary
+                union
+                select 'TABLE_NO_PK_COUNT' as variable_name,
+                    total_tables_without_primary_key as variable_value
+                from (
+                        select table_schema,
+                            sum(if(has_primary_key = 0, 1, 0)) as total_tables_without_primary_key
+                        from (
+                                select t.table_schema as table_schema,
+                                    t.table_name as table_name,
+                                    t.table_rows as table_rows,
+                                    t.DATA_LENGTH as DATA_LENGTH,
+                                    t.INDEX_LENGTH as INDEX_LENGTH,
+                                    t.DATA_LENGTH + t.INDEX_LENGTH as total_length,
+                                    t.ROW_FORMAT as row_format,
+                                    t.TABLE_TYPE as table_type,
+                                    t.ENGINE as table_engine,
+                                    if(pks.table_name is not null, 1, 0) as has_primary_key
+                                from information_schema.TABLES t
+                                    left join (
+                                        select table_schema,
+                                            TABLE_NAME
+                                        from information_schema.statistics
+                                        where table_schema not in (
+                                                'mysql',
+                                                'information_schema',
+                                                'performance_schema',
+                                                'sys'
+                                            )
+                                        group by table_schema,
+                                            TABLE_NAME,
+                                            index_name
+                                        having SUM(
+                                                if(
+                                                    non_unique = 0
+                                                    and NULLABLE != 'YES',
+                                                    1,
+                                                    0
+                                                )
+                                            ) = count(*)
+                                    ) pks on (
+                                        t.table_schema = pks.table_schema
+                                        and t.TABLE_NAME = pks.TABLE_NAME
+                                    )
+                                where t.table_schema not in (
+                                        'mysql',
+                                        'information_schema',
+                                        'performance_schema',
+                                        'sys'
+                                    )
+                            ) user_tables
+                        group by user_tables.table_schema
+                    ) data_summary
+                union
+                select 'MYSQLX_PLUGIN' as variable_name,
+                    p.mysqlx_plugin_enabled as variable_value
+                from (
+                        select if(agg.mysqlx_plugin > 0, 1, 0) as mysqlx_plugin_enabled
+                        from (
+                                select sum(
+                                        if(
+                                            upper(p.plugin_name) like '%MYSQLX%',
+                                            1,
+                                            0
+                                        )
+                                    ) as mysqlx_plugin
+                                from (
+                                        select p.plugin_name as plugin_name,
+                                            p.PLUGIN_STATUS
+                                        from information_schema.PLUGINS p
+                                    ) p
+                            ) agg
+                    ) p
+                union
+                select 'MEMCACHED_PLUGIN' as variable_name,
+                    p.memcached_plugin_enabled as variable_value
+                from (
+                        select if(agg.memcached_plugin > 0, 1, 0) as memcached_plugin_enabled
+                        from (
+                                select sum(
+                                        if(
+                                            upper(p.plugin_name) like '%MEMCACHED%',
+                                            1,
+                                            0
+                                        )
+                                    ) as memcached_plugin
+                                from (
+                                        select p.plugin_name as plugin_name,
+                                            p.PLUGIN_STATUS
+                                        from information_schema.PLUGINS p
+                                    ) p
+                            ) agg
+                    ) p
+                union
+                select 'CLONE_PLUGIN' as variable_name,
+                    p.clone_plugin_enabled as variable_value
+                from (
+                        select if(agg.clone_plugin > 0, 1, 0) as clone_plugin_enabled
+                        from (
+                                select sum(
+                                        if(
+                                            upper(p.plugin_name) like '%CLONE%',
+                                            1,
+                                            0
+                                        )
+                                    ) as clone_plugin
+                                from (
+                                        select p.plugin_name as plugin_name,
+                                            p.PLUGIN_STATUS
+                                        from information_schema.PLUGINS p
+                                    ) p
+                            ) agg
+                    ) p
+                union
+                select 'KEYRING_PLUGIN' as variable_name,
+                    p.keyring_plugin_enabled as variable_value
+                from (
+                        select if(agg.keyring_plugin > 0, 1, 0) as keyring_plugin_enabled
+                        from (
+                                select sum(
+                                        if(
+                                            upper(p.plugin_name) like '%KEYRING%',
+                                            1,
+                                            0
+                                        )
+                                    ) as keyring_plugin
+                                from (
+                                        select p.plugin_name as plugin_name,
+                                            p.PLUGIN_STATUS
+                                        from information_schema.PLUGINS p
+                                    ) p
+                            ) agg
+                    ) p
+                union
+                select 'VALIDATE_PASSWORD_PLUGIN' as variable_name,
+                    p.validate_password_plugin_enabled as variable_value
+                from (
+                        select if(agg.validate_password_plugin > 0, 1, 0) as validate_password_plugin_enabled
+                        from (
+                                select sum(
+                                        if(
+                                            upper(p.plugin_name) like '%VALIDATE_PASSWORD%',
+                                            1,
+                                            0
+                                        )
+                                    ) as validate_password_plugin
+                                from (
+                                        select p.plugin_name as plugin_name,
+                                            p.PLUGIN_STATUS
+                                        from information_schema.PLUGINS p
+                                    ) p
+                            ) agg
+                    ) p
+                union
+                select 'THREAD_POOL_PLUGIN' as variable_name,
+                    p.thread_pool_plugin_enabled as variable_value
+                from (
+                        select if(agg.thread_pool_plugin > 0, 1, 0) as thread_pool_plugin_enabled
+                        from (
+                                select sum(
+                                        if(
+                                            upper(p.plugin_name) like '%THREAD_POOL%',
+                                            1,
+                                            0
+                                        )
+                                    ) as thread_pool_plugin
+                                from (
+                                        select p.plugin_name as plugin_name,
+                                            p.PLUGIN_STATUS
+                                        from information_schema.PLUGINS p
+                                    ) p
+                            ) agg
+                    ) p
+                union
+                select 'FIREWALL_PLUGIN' as variable_name,
+                    p.firewall_plugin_enabled as variable_value
+                from (
+                        select if(agg.firewall_plugin > 0, 1, 0) as firewall_plugin_enabled
+                        from (
+                                select sum(
+                                        if(
+                                            upper(p.plugin_name) like '%FIREWALL%',
+                                            1,
+                                            0
+                                        )
+                                    ) as firewall_plugin
+                                from (
+                                        select p.plugin_name as plugin_name,
+                                            p.PLUGIN_STATUS
+                                        from information_schema.PLUGINS p
+                                    ) p
+                            ) agg
+                    ) p
+                union
+                select 'VERSION_NUM' as variable_name,
+                    regexp_substr(gv.variable_value, '[0-9]+\.[0-9]+\.[0-9]+') as variable_value
+                from performance_schema.global_variables gv
+                where gv.variable_name = 'VERSION'
+            ) calculated_metrics
+    ) src;

--- a/scripts/collector/mysql/sql/config.sql
+++ b/scripts/collector/mysql/sql/config.sql
@@ -559,8 +559,10 @@ from (
                     ) p
                 union
                 select 'VERSION_NUM' as variable_name,
-                    gv.variable_value as variable_value
-                from performance_schema.global_variables gv
-                where gv.variable_name = 'VERSION'
+                    if(
+                        version() rlike '^[0-9]+\.[0-9]+\.[0-9]+$' = 1,
+                        version(),
+                        SUBSTRING_INDEX(VERSION(), '.', 2) || '.0'
+                    ) as variable_value
             ) calculated_metrics
     ) src;

--- a/scripts/collector/mysql/sql/data_types.sql
+++ b/scripts/collector/mysql/sql/data_types.sql
@@ -1,21 +1,3 @@
-with src as (
-    select i.table_catalog as table_catalog,
-        i.TABLE_SCHEMA as table_schema,
-        i.TABLE_NAME as table_name,
-        i.DATA_TYPE as data_type,
-        count(1) as data_type_count
-    from information_schema.columns i
-    where i.TABLE_SCHEMA not in (
-            'mysql',
-            'information_schema',
-            'performance_schema',
-            'sys'
-        )
-    group by i.table_catalog,
-        i.TABLE_SCHEMA,
-        i.TABLE_NAME,
-        i.DATA_TYPE
-)
 select concat(char(34), @PKEY, char(34)) as pkey,
     concat(char(34), @DMA_SOURCE_ID, char(34)) as dma_source_id,
     concat(char(34), @DMA_MANUAL_ID, char(34)) as dma_manual_id,
@@ -24,4 +6,21 @@ select concat(char(34), @PKEY, char(34)) as pkey,
     concat(char(34), src.table_name, char(34)) as table_name,
     concat(char(34), src.data_type, char(34)) as data_type,
     src.data_type_count as data_type_count
-from src;
+from (
+        select i.table_catalog as table_catalog,
+            i.TABLE_SCHEMA as table_schema,
+            i.TABLE_NAME as table_name,
+            i.DATA_TYPE as data_type,
+            count(1) as data_type_count
+        from information_schema.columns i
+        where i.TABLE_SCHEMA not in (
+                'mysql',
+                'information_schema',
+                'performance_schema',
+                'sys'
+            )
+        group by i.table_catalog,
+            i.TABLE_SCHEMA,
+            i.TABLE_NAME,
+            i.DATA_TYPE
+    ) src;

--- a/scripts/collector/mysql/sql/database_details.sql
+++ b/scripts/collector/mysql/sql/database_details.sql
@@ -1,149 +1,3 @@
-with table_partitions as (
-    select TABLE_SCHEMA,
-        TABLE_NAME,
-        PARTITION_METHOD,
-        SUBPARTITION_METHOD,
-        count(1) as PARTITION_COUNT
-    from information_schema.PARTITIONS
-    where table_schema not in (
-            'mysql',
-            'information_schema',
-            'performance_schema',
-            'sys'
-        )
-    group by TABLE_SCHEMA,
-        TABLE_NAME,
-        PARTITION_METHOD,
-        SUBPARTITION_METHOD
-),
-tables_with_pks as (
-    select table_schema,
-        TABLE_NAME
-    from information_schema.statistics
-    where table_schema not in (
-            'mysql',
-            'information_schema',
-            'performance_schema',
-            'sys'
-        )
-    group by table_schema,
-        TABLE_NAME,
-        index_name
-    having SUM(
-            if(
-                non_unique = 0
-                and NULLABLE != 'YES',
-                1,
-                0
-            )
-        ) = count(*)
-),
-table_indexes as (
-    select s.table_schema,
-        s.table_name,
-        count(1) as index_count,
-        sum(
-            if(s.INDEX_TYPE = 'FULLTEXT', 1, 0)
-        ) as fulltext_index_count,
-        sum(if(s.INDEX_TYPE = 'SPATIAL', 1, 0)) as spatial_index_count
-    from information_schema.STATISTICS s
-    where s.table_schema not in (
-            'mysql',
-            'information_schema',
-            'performance_schema',
-            'sys'
-        )
-    group by s.table_schema,
-        s.table_name
-),
-user_tables as (
-    select t.table_schema as table_schema,
-        t.table_name as table_name,
-        t.table_rows as table_rows,
-        t.DATA_LENGTH as DATA_LENGTH,
-        t.INDEX_LENGTH as INDEX_LENGTH,
-        t.DATA_LENGTH + t.INDEX_LENGTH as total_length,
-        t.ROW_FORMAT as row_format,
-        t.TABLE_TYPE as table_type,
-        t.ENGINE as table_engine,
-        if(pks.table_name is not null, 1, 0) as has_primary_key,
-        if(t.ROW_FORMAT = 'COMPRESSED', 1, 0) as is_compressed,
-        if(pt.PARTITION_METHOD is not null, 1, 0) as is_partitioned,
-        COALESCE(pt.PARTITION_COUNT, 0) as partition_count,
-        COALESCE(idx.index_count, 0) as index_count,
-        COALESCE(idx.fulltext_index_count, 0) as fulltext_index_count,
-        COALESCE(idx.spatial_index_count, 0) as spatial_index_count
-    from information_schema.TABLES t
-        left join table_partitions pt on (
-            t.table_schema = pt.table_schema
-            and t.TABLE_NAME = pt.TABLE_NAME
-        )
-        left join tables_with_pks pks on (
-            t.table_schema = pks.table_schema
-            and t.TABLE_NAME = pks.TABLE_NAME
-        )
-        left join table_indexes idx on (
-            t.table_schema = idx.table_schema
-            and t.TABLE_NAME = idx.TABLE_NAME
-        )
-    where t.table_schema not in (
-            'mysql',
-            'information_schema',
-            'performance_schema',
-            'sys'
-        )
-),
-src as (
-    select table_schema,
-        count(table_name) as total_table_count,
-        sum(if(upper(table_engine) = 'INNODB', 1, 0)) as innodb_table_count,
-        sum(if(upper(table_engine) != 'INNODB', 1, 0)) as non_innodb_table_count,
-        sum(table_rows) as total_row_count,
-        sum(
-            if(upper(table_engine) = 'INNODB', table_rows, 0)
-        ) as innodb_table_row_count,
-        sum(
-            if(upper(table_engine) != 'INNODB', table_rows, 0)
-        ) as non_innodb_table_row_count,
-        sum(data_length) as total_data_size_bytes,
-        sum(
-            if(upper(table_engine) = 'INNODB', data_length, 0)
-        ) as innodb_data_size_bytes,
-        sum(
-            if(upper(table_engine) != 'INNODB', data_length, 0)
-        ) as non_innodb_data_size_bytes,
-        sum(index_length) as total_index_size_bytes,
-        sum(
-            if(upper(table_engine) = 'INNODB', index_length, 0)
-        ) as innodb_index_size_bytes,
-        sum(
-            if(upper(table_engine) != 'INNODB', index_length, 0)
-        ) as non_innodb_index_size_bytes,
-        sum(total_length) as total_size_bytes,
-        sum(
-            if(
-                upper(table_engine) = 'INNODB',
-                total_length,
-                0
-            )
-        ) as innodb_total_size_bytes,
-        sum(
-            if(
-                upper(table_engine) != 'INNODB',
-                total_length,
-                0
-            )
-        ) as non_innodb_total_size_bytes,
-        sum(index_count) as total_index_count,
-        sum(
-            if(upper(table_engine) = 'INNODB', index_count, 0)
-        ) as innodb_index_count,
-        sum(
-            if(upper(table_engine) != 'INNODB', index_count, 0)
-        ) as non_innodb_index_count
-    from user_tables
-    group by table_schema
-)
 select
     /*+ MAX_EXECUTION_TIME(5000) */
     concat(char(34), @PKEY, char(34)) as pkey,
@@ -168,4 +22,145 @@ select
     src.total_index_count as total_index_count,
     src.innodb_index_count as innodb_index_count,
     src.non_innodb_index_count as non_innodb_index_count
-from src;
+from (
+        select table_schema,
+            count(table_name) as total_table_count,
+            sum(if(upper(table_engine) = 'INNODB', 1, 0)) as innodb_table_count,
+            sum(if(upper(table_engine) != 'INNODB', 1, 0)) as non_innodb_table_count,
+            sum(table_rows) as total_row_count,
+            sum(
+                if(upper(table_engine) = 'INNODB', table_rows, 0)
+            ) as innodb_table_row_count,
+            sum(
+                if(upper(table_engine) != 'INNODB', table_rows, 0)
+            ) as non_innodb_table_row_count,
+            sum(data_length) as total_data_size_bytes,
+            sum(
+                if(upper(table_engine) = 'INNODB', data_length, 0)
+            ) as innodb_data_size_bytes,
+            sum(
+                if(upper(table_engine) != 'INNODB', data_length, 0)
+            ) as non_innodb_data_size_bytes,
+            sum(index_length) as total_index_size_bytes,
+            sum(
+                if(upper(table_engine) = 'INNODB', index_length, 0)
+            ) as innodb_index_size_bytes,
+            sum(
+                if(upper(table_engine) != 'INNODB', index_length, 0)
+            ) as non_innodb_index_size_bytes,
+            sum(total_length) as total_size_bytes,
+            sum(
+                if(
+                    upper(table_engine) = 'INNODB',
+                    total_length,
+                    0
+                )
+            ) as innodb_total_size_bytes,
+            sum(
+                if(
+                    upper(table_engine) != 'INNODB',
+                    total_length,
+                    0
+                )
+            ) as non_innodb_total_size_bytes,
+            sum(index_count) as total_index_count,
+            sum(
+                if(upper(table_engine) = 'INNODB', index_count, 0)
+            ) as innodb_index_count,
+            sum(
+                if(upper(table_engine) != 'INNODB', index_count, 0)
+            ) as non_innodb_index_count
+        from (
+                select t.table_schema as table_schema,
+                    t.table_name as table_name,
+                    t.table_rows as table_rows,
+                    t.DATA_LENGTH as DATA_LENGTH,
+                    t.INDEX_LENGTH as INDEX_LENGTH,
+                    t.DATA_LENGTH + t.INDEX_LENGTH as total_length,
+                    t.ROW_FORMAT as row_format,
+                    t.TABLE_TYPE as table_type,
+                    t.ENGINE as table_engine,
+                    if(pks.table_name is not null, 1, 0) as has_primary_key,
+                    if(t.ROW_FORMAT = 'COMPRESSED', 1, 0) as is_compressed,
+                    if(pt.PARTITION_METHOD is not null, 1, 0) as is_partitioned,
+                    COALESCE(pt.PARTITION_COUNT, 0) as partition_count,
+                    COALESCE(idx.index_count, 0) as index_count,
+                    COALESCE(idx.fulltext_index_count, 0) as fulltext_index_count,
+                    COALESCE(idx.spatial_index_count, 0) as spatial_index_count
+                from information_schema.TABLES t
+                    left join (
+                        select TABLE_SCHEMA,
+                            TABLE_NAME,
+                            PARTITION_METHOD,
+                            SUBPARTITION_METHOD,
+                            count(1) as PARTITION_COUNT
+                        from information_schema.PARTITIONS
+                        where table_schema not in (
+                                'mysql',
+                                'information_schema',
+                                'performance_schema',
+                                'sys'
+                            )
+                        group by TABLE_SCHEMA,
+                            TABLE_NAME,
+                            PARTITION_METHOD,
+                            SUBPARTITION_METHOD
+                    ) pt on (
+                        t.table_schema = pt.table_schema
+                        and t.TABLE_NAME = pt.TABLE_NAME
+                    )
+                    left join (
+                        select table_schema,
+                            TABLE_NAME
+                        from information_schema.statistics
+                        where table_schema not in (
+                                'mysql',
+                                'information_schema',
+                                'performance_schema',
+                                'sys'
+                            )
+                        group by table_schema,
+                            TABLE_NAME,
+                            index_name
+                        having SUM(
+                                if(
+                                    non_unique = 0
+                                    and NULLABLE != 'YES',
+                                    1,
+                                    0
+                                )
+                            ) = count(*)
+                    ) pks on (
+                        t.table_schema = pks.table_schema
+                        and t.TABLE_NAME = pks.TABLE_NAME
+                    )
+                    left join (
+                        select s.table_schema,
+                            s.table_name,
+                            count(1) as index_count,
+                            sum(
+                                if(s.INDEX_TYPE = 'FULLTEXT', 1, 0)
+                            ) as fulltext_index_count,
+                            sum(if(s.INDEX_TYPE = 'SPATIAL', 1, 0)) as spatial_index_count
+                        from information_schema.STATISTICS s
+                        where s.table_schema not in (
+                                'mysql',
+                                'information_schema',
+                                'performance_schema',
+                                'sys'
+                            )
+                        group by s.table_schema,
+                            s.table_name
+                    ) idx on (
+                        t.table_schema = idx.table_schema
+                        and t.TABLE_NAME = idx.TABLE_NAME
+                    )
+                where t.table_schema not in (
+                        'mysql',
+                        'information_schema',
+                        'performance_schema',
+                        'sys'
+                    )
+            ) user_tables
+        group by table_schema
+    ) src;

--- a/scripts/collector/mysql/sql/engines.sql
+++ b/scripts/collector/mysql/sql/engines.sql
@@ -1,12 +1,3 @@
-with src as (
-    select i.ENGINE as engine_name,
-        i.SUPPORT as engine_support,
-        i.TRANSACTIONS as engine_transactions,
-        i.xa as engine_xa,
-        i.SAVEPOINTS as engine_savepoints,
-        i.COMMENT as engine_comment
-    from information_schema.ENGINES i
-)
 select concat(char(34), @PKEY, char(34)) as pkey,
     concat(char(34), @DMA_SOURCE_ID, char(34)) as dma_source_id,
     concat(char(34), @DMA_MANUAL_ID, char(34)) as dma_manual_id,
@@ -16,4 +7,12 @@ select concat(char(34), @PKEY, char(34)) as pkey,
     concat(char(34), src.engine_xa, char(34)) as engine_xa,
     concat(char(34), src.engine_savepoints, char(34)) as engine_savepoints,
     concat(char(34), src.engine_comment, char(34)) as engine_comment
-from src;
+from (
+        select i.ENGINE as engine_name,
+            i.SUPPORT as engine_support,
+            i.TRANSACTIONS as engine_transactions,
+            i.xa as engine_xa,
+            i.SAVEPOINTS as engine_savepoints,
+            i.COMMENT as engine_comment
+        from information_schema.ENGINES i
+    ) src;

--- a/scripts/collector/mysql/sql/plugins.sql
+++ b/scripts/collector/mysql/sql/plugins.sql
@@ -1,17 +1,3 @@
-with src as (
-    select plugin_name as plugin_name,
-        plugin_version as plugin_version,
-        plugin_status as plugin_status,
-        plugin_type as plugin_type,
-        plugin_type_version as plugin_type_version,
-        plugin_library as plugin_library,
-        plugin_library_version as plugin_library_version,
-        plugin_author as plugin_author,
-        plugin_description as plugin_description,
-        plugin_license as plugin_license,
-        load_option as load_option
-    from information_schema.PLUGINS
-)
 select concat(char(34), @PKEY, char(34)) as pkey,
     concat(char(34), @DMA_SOURCE_ID, char(34)) as dma_source_id,
     concat(char(34), @DMA_MANUAL_ID, char(34)) as dma_manual_id,
@@ -26,4 +12,17 @@ select concat(char(34), @PKEY, char(34)) as pkey,
     concat(char(34), src.plugin_description, char(34)) as plugin_description,
     concat(char(34), src.plugin_license, char(34)) as plugin_license,
     concat(char(34), src.load_option, char(34)) as load_option
-from src;
+from (
+        select plugin_name as plugin_name,
+            plugin_version as plugin_version,
+            plugin_status as plugin_status,
+            plugin_type as plugin_type,
+            plugin_type_version as plugin_type_version,
+            plugin_library as plugin_library,
+            plugin_library_version as plugin_library_version,
+            plugin_author as plugin_author,
+            plugin_description as plugin_description,
+            plugin_license as plugin_license,
+            load_option as load_option
+        from information_schema.PLUGINS
+    ) src;

--- a/scripts/collector/mysql/sql/schema_objects.sql
+++ b/scripts/collector/mysql/sql/schema_objects.sql
@@ -1,174 +1,3 @@
-with src as (
-    select i.CONSTRAINT_CATALOG as object_catalog,
-        i.CONSTRAINT_SCHEMA as object_schema,
-        'CONSTRAINT' as object_category,
-        concat(i.CONSTRAINT_TYPE, ' CONSTRAINT') as object_type,
-        i.TABLE_SCHEMA as object_owner_schema,
-        i.TABLE_NAME as object_owner,
-        i.CONSTRAINT_NAME as object_name
-    from information_schema.TABLE_CONSTRAINTS i
-    where i.CONSTRAINT_SCHEMA not in (
-            'mysql',
-            'information_schema',
-            'performance_schema',
-            'sys'
-        )
-    union
-    select i.TRIGGER_CATALOG as object_catalog,
-        i.TRIGGER_SCHEMA as object_schema,
-        'TRIGGER' as object_category,
-        concat(
-            i.ACTION_TIMING,
-            ' ',
-            i.EVENT_MANIPULATION,
-            ' TRIGGER'
-        ) as object_type,
-        i.TRIGGER_SCHEMA as object_owner_schema,
-        i.definer as object_owner,
-        i.TRIGGER_NAME as object_name
-    from information_schema.TRIGGERS i
-    where i.TRIGGER_SCHEMA not in (
-            'mysql',
-            'information_schema',
-            'performance_schema',
-            'sys'
-        )
-    union
-    select i.TABLE_CATALOG as object_catalog,
-        i.TABLE_SCHEMA as object_schema,
-        'VIEW' as object_category,
-        i.TABLE_TYPE as object_type,
-        null as object_schema_schema,
-        null as object_owner,
-        i.TABLE_NAME as object_name
-    from information_schema.TABLES i
-    where i.table_type = 'VIEW'
-        and i.TABLE_SCHEMA not in (
-            'mysql',
-            'information_schema',
-            'performance_schema',
-            'sys'
-        )
-    union
-    select i.TABLE_CATALOG as object_catalog,
-        i.TABLE_SCHEMA as object_schema,
-        'TABLE' as object_category,
-        if(
-            pt.PARTITION_METHOD is null,
-            'TABLE',
-            if(
-                pt.SUBPARTITION_METHOD is not null,
-                concat(
-                    'TABLE-COMPOSITE_PARTITIONED-',
-                    pt.PARTITION_METHOD,
-                    '-',
-                    pt.SUBPARTITION_METHOD
-                ),
-                concat('TABLE-PARTITIONED-', pt.PARTITION_METHOD)
-            )
-        ) as object_type,
-        null as object_schema_schema,
-        null as object_owner,
-        i.TABLE_NAME as object_name
-    from information_schema.TABLES i
-        left join (
-            select TABLE_SCHEMA,
-                TABLE_NAME,
-                PARTITION_METHOD,
-                SUBPARTITION_METHOD,
-                count(1) as PARTITION_COUNT
-            from information_schema.PARTITIONS
-            where table_schema not in (
-                    'mysql',
-                    'information_schema',
-                    'performance_schema',
-                    'sys'
-                )
-            group by TABLE_SCHEMA,
-                TABLE_NAME,
-                PARTITION_METHOD,
-                SUBPARTITION_METHOD
-        ) pt on (
-            i.TABLE_NAME = pt.TABLE_NAME
-            and i.TABLE_SCHEMA = pt.TABLE_SCHEMA
-        )
-    where i.table_type != 'VIEW'
-        and i.TABLE_SCHEMA not in (
-            'mysql',
-            'information_schema',
-            'performance_schema',
-            'sys'
-        )
-    union
-    select i.ROUTINE_CATALOG as object_catalog,
-        i.ROUTINE_SCHEMA as object_schema,
-        'PROCEDURE' as object_category,
-        i.ROUTINE_TYPE as object_type,
-        i.ROUTINE_SCHEMA as object_owner_schema,
-        i.definer as object_owner,
-        i.ROUTINE_NAME as object_name
-    from information_schema.ROUTINES i
-    where i.ROUTINE_TYPE = 'PROCEDURE'
-        and i.ROUTINE_SCHEMA not in (
-            'mysql',
-            'information_schema',
-            'performance_schema',
-            'sys'
-        )
-    union
-    select i.ROUTINE_CATALOG as object_catalog,
-        i.ROUTINE_SCHEMA as object_schema,
-        'FUNCTION' as object_category,
-        i.ROUTINE_TYPE as object_type,
-        i.ROUTINE_SCHEMA as object_owner_schema,
-        i.definer as object_owner,
-        i.ROUTINE_NAME as object_name
-    from information_schema.ROUTINES i
-    where i.ROUTINE_TYPE = 'FUNCTION'
-        and i.ROUTINE_SCHEMA not in (
-            'mysql',
-            'information_schema',
-            'performance_schema',
-            'sys'
-        )
-    union
-    select i.EVENT_CATALOG as object_catalog,
-        i.EVENT_SCHEMA as object_schema,
-        'EVENT' as object_category,
-        i.EVENT_TYPE as object_type,
-        i.EVENT_SCHEMA as object_owner_schema,
-        i.definer as object_owner,
-        i.EVENT_NAME as object_name
-    from information_schema.EVENTS i
-    where i.EVENT_SCHEMA not in (
-            'mysql',
-            'information_schema',
-            'performance_schema',
-            'sys'
-        )
-    union
-    select i.TABLE_CATALOG as object_catalog,
-        i.TABLE_SCHEMA as object_schema,
-        'INDEX' as object_category,
-        case
-            when i.INDEX_TYPE = 'BTREE' then 'INDEX'
-            when i.INDEX_TYPE = 'HASH' then 'INDEX-HASH'
-            when i.INDEX_TYPE = 'FULLTEXT' then 'INDEX-FULLTEXT'
-            when i.INDEX_TYPE = 'SPATIAL' then 'INDEX-SPATIAL'
-            else 'INDEX-UNCATEGORIZED'
-        end as object_type,
-        i.TABLE_SCHEMA as object_owner_schema,
-        i.TABLE_NAME as object_owner,
-        i.INDEX_NAME as object_name
-    from information_schema.STATISTICS i
-    where i.INDEX_NAME != 'PRIMARY'
-        and i.TABLE_SCHEMA not in (
-            'mysql',
-            'information_schema',
-            'performance_schema',
-            'sys'
-        )
-)
 select concat(char(34), @PKEY, char(34)) as pkey,
     concat(char(34), @DMA_SOURCE_ID, char(34)) as dma_source_id,
     concat(char(34), @DMA_MANUAL_ID, char(34)) as dma_manual_id,
@@ -179,4 +8,174 @@ select concat(char(34), @PKEY, char(34)) as pkey,
     concat(char(34), src.object_owner_schema, char(34)) as object_owner_schema,
     concat(char(34), src.object_owner, char(34)) as object_owner,
     concat(char(34), src.object_name, char(34)) as object_name
-from src;
+from (
+        select i.CONSTRAINT_CATALOG as object_catalog,
+            i.CONSTRAINT_SCHEMA as object_schema,
+            'CONSTRAINT' as object_category,
+            concat(i.CONSTRAINT_TYPE, ' CONSTRAINT') as object_type,
+            i.TABLE_SCHEMA as object_owner_schema,
+            i.TABLE_NAME as object_owner,
+            i.CONSTRAINT_NAME as object_name
+        from information_schema.TABLE_CONSTRAINTS i
+        where i.CONSTRAINT_SCHEMA not in (
+                'mysql',
+                'information_schema',
+                'performance_schema',
+                'sys'
+            )
+        union
+        select i.TRIGGER_CATALOG as object_catalog,
+            i.TRIGGER_SCHEMA as object_schema,
+            'TRIGGER' as object_category,
+            concat(
+                i.ACTION_TIMING,
+                ' ',
+                i.EVENT_MANIPULATION,
+                ' TRIGGER'
+            ) as object_type,
+            i.TRIGGER_SCHEMA as object_owner_schema,
+            i.definer as object_owner,
+            i.TRIGGER_NAME as object_name
+        from information_schema.TRIGGERS i
+        where i.TRIGGER_SCHEMA not in (
+                'mysql',
+                'information_schema',
+                'performance_schema',
+                'sys'
+            )
+        union
+        select i.TABLE_CATALOG as object_catalog,
+            i.TABLE_SCHEMA as object_schema,
+            'VIEW' as object_category,
+            i.TABLE_TYPE as object_type,
+            null as object_schema_schema,
+            null as object_owner,
+            i.TABLE_NAME as object_name
+        from information_schema.TABLES i
+        where i.table_type = 'VIEW'
+            and i.TABLE_SCHEMA not in (
+                'mysql',
+                'information_schema',
+                'performance_schema',
+                'sys'
+            )
+        union
+        select i.TABLE_CATALOG as object_catalog,
+            i.TABLE_SCHEMA as object_schema,
+            'TABLE' as object_category,
+            if(
+                pt.PARTITION_METHOD is null,
+                'TABLE',
+                if(
+                    pt.SUBPARTITION_METHOD is not null,
+                    concat(
+                        'TABLE-COMPOSITE_PARTITIONED-',
+                        pt.PARTITION_METHOD,
+                        '-',
+                        pt.SUBPARTITION_METHOD
+                    ),
+                    concat('TABLE-PARTITIONED-', pt.PARTITION_METHOD)
+                )
+            ) as object_type,
+            null as object_schema_schema,
+            null as object_owner,
+            i.TABLE_NAME as object_name
+        from information_schema.TABLES i
+            left join (
+                select TABLE_SCHEMA,
+                    TABLE_NAME,
+                    PARTITION_METHOD,
+                    SUBPARTITION_METHOD,
+                    count(1) as PARTITION_COUNT
+                from information_schema.PARTITIONS
+                where table_schema not in (
+                        'mysql',
+                        'information_schema',
+                        'performance_schema',
+                        'sys'
+                    )
+                group by TABLE_SCHEMA,
+                    TABLE_NAME,
+                    PARTITION_METHOD,
+                    SUBPARTITION_METHOD
+            ) pt on (
+                i.TABLE_NAME = pt.TABLE_NAME
+                and i.TABLE_SCHEMA = pt.TABLE_SCHEMA
+            )
+        where i.table_type != 'VIEW'
+            and i.TABLE_SCHEMA not in (
+                'mysql',
+                'information_schema',
+                'performance_schema',
+                'sys'
+            )
+        union
+        select i.ROUTINE_CATALOG as object_catalog,
+            i.ROUTINE_SCHEMA as object_schema,
+            'PROCEDURE' as object_category,
+            i.ROUTINE_TYPE as object_type,
+            i.ROUTINE_SCHEMA as object_owner_schema,
+            i.definer as object_owner,
+            i.ROUTINE_NAME as object_name
+        from information_schema.ROUTINES i
+        where i.ROUTINE_TYPE = 'PROCEDURE'
+            and i.ROUTINE_SCHEMA not in (
+                'mysql',
+                'information_schema',
+                'performance_schema',
+                'sys'
+            )
+        union
+        select i.ROUTINE_CATALOG as object_catalog,
+            i.ROUTINE_SCHEMA as object_schema,
+            'FUNCTION' as object_category,
+            i.ROUTINE_TYPE as object_type,
+            i.ROUTINE_SCHEMA as object_owner_schema,
+            i.definer as object_owner,
+            i.ROUTINE_NAME as object_name
+        from information_schema.ROUTINES i
+        where i.ROUTINE_TYPE = 'FUNCTION'
+            and i.ROUTINE_SCHEMA not in (
+                'mysql',
+                'information_schema',
+                'performance_schema',
+                'sys'
+            )
+        union
+        select i.EVENT_CATALOG as object_catalog,
+            i.EVENT_SCHEMA as object_schema,
+            'EVENT' as object_category,
+            i.EVENT_TYPE as object_type,
+            i.EVENT_SCHEMA as object_owner_schema,
+            i.definer as object_owner,
+            i.EVENT_NAME as object_name
+        from information_schema.EVENTS i
+        where i.EVENT_SCHEMA not in (
+                'mysql',
+                'information_schema',
+                'performance_schema',
+                'sys'
+            )
+        union
+        select i.TABLE_CATALOG as object_catalog,
+            i.TABLE_SCHEMA as object_schema,
+            'INDEX' as object_category,
+            case
+                when i.INDEX_TYPE = 'BTREE' then 'INDEX'
+                when i.INDEX_TYPE = 'HASH' then 'INDEX-HASH'
+                when i.INDEX_TYPE = 'FULLTEXT' then 'INDEX-FULLTEXT'
+                when i.INDEX_TYPE = 'SPATIAL' then 'INDEX-SPATIAL'
+                else 'INDEX-UNCATEGORIZED'
+            end as object_type,
+            i.TABLE_SCHEMA as object_owner_schema,
+            i.TABLE_NAME as object_owner,
+            i.INDEX_NAME as object_name
+        from information_schema.STATISTICS i
+        where i.INDEX_NAME != 'PRIMARY'
+            and i.TABLE_SCHEMA not in (
+                'mysql',
+                'information_schema',
+                'performance_schema',
+                'sys'
+            )
+    ) src;

--- a/scripts/collector/mysql/sql/table_details.sql
+++ b/scripts/collector/mysql/sql/table_details.sql
@@ -1,98 +1,3 @@
-with table_partitions as (
-    select TABLE_SCHEMA,
-        TABLE_NAME,
-        PARTITION_METHOD,
-        SUBPARTITION_METHOD,
-        count(1) as PARTITION_COUNT
-    from information_schema.PARTITIONS
-    where table_schema not in (
-            'mysql',
-            'information_schema',
-            'performance_schema',
-            'sys'
-        )
-    group by TABLE_SCHEMA,
-        TABLE_NAME,
-        PARTITION_METHOD,
-        SUBPARTITION_METHOD
-),
-tables_with_pks as (
-    select table_schema,
-        TABLE_NAME
-    from information_schema.statistics
-    where table_schema not in (
-            'mysql',
-            'information_schema',
-            'performance_schema',
-            'sys'
-        )
-    group by table_schema,
-        TABLE_NAME,
-        index_name
-    having SUM(
-            if(
-                non_unique = 0
-                and NULLABLE != 'YES',
-                1,
-                0
-            )
-        ) = count(*)
-),
-table_indexes as (
-    select s.table_schema,
-        s.table_name,
-        count(1) as index_count,
-        sum(
-            if(s.INDEX_TYPE = 'FULLTEXT', 1, 0)
-        ) as fulltext_index_count,
-        sum(if(s.INDEX_TYPE = 'SPATIAL', 1, 0)) as spatial_index_count
-    from information_schema.STATISTICS s
-    where s.table_schema not in (
-            'mysql',
-            'information_schema',
-            'performance_schema',
-            'sys'
-        )
-    group by s.table_schema,
-        s.table_name
-),
-user_tables as (
-    select t.table_schema as table_schema,
-        t.table_name as table_name,
-        t.table_rows as table_rows,
-        t.DATA_LENGTH as DATA_LENGTH,
-        t.INDEX_LENGTH as INDEX_LENGTH,
-        t.DATA_LENGTH + t.INDEX_LENGTH as total_length,
-        t.ROW_FORMAT as row_format,
-        t.TABLE_TYPE as table_type,
-        t.ENGINE as table_engine,
-        if(pks.table_name is not null, 1, 0) as has_primary_key,
-        if(t.ROW_FORMAT = 'COMPRESSED', 1, 0) as is_compressed,
-        if(pt.PARTITION_METHOD is not null, 1, 0) as is_partitioned,
-        COALESCE(pt.PARTITION_COUNT, 0) as partition_count,
-        COALESCE(idx.index_count, 0) as index_count,
-        COALESCE(idx.fulltext_index_count, 0) as fulltext_index_count,
-        COALESCE(idx.spatial_index_count, 0) as spatial_index_count
-    from information_schema.TABLES t
-        left join table_partitions pt on (
-            t.table_schema = pt.table_schema
-            and t.TABLE_NAME = pt.TABLE_NAME
-        )
-        left join tables_with_pks pks on (
-            t.table_schema = pks.table_schema
-            and t.TABLE_NAME = pks.TABLE_NAME
-        )
-        left join table_indexes idx on (
-            t.table_schema = idx.table_schema
-            and t.TABLE_NAME = idx.TABLE_NAME
-        )
-    where t.table_schema not in (
-            'mysql',
-            'information_schema',
-            'performance_schema',
-            'sys'
-        )
-)
 select
     /*+ MAX_EXECUTION_TIME(5000) */
     concat(char(34), @PKEY, char(34)) as pkey,
@@ -109,4 +14,95 @@ select
     partition_count as partition_count,
     index_count as index_count,
     fulltext_index_count as fulltext_index_count
-from user_tables;
+from (
+        select t.table_schema as table_schema,
+            t.table_name as table_name,
+            t.table_rows as table_rows,
+            t.DATA_LENGTH as DATA_LENGTH,
+            t.INDEX_LENGTH as INDEX_LENGTH,
+            t.DATA_LENGTH + t.INDEX_LENGTH as total_length,
+            t.ROW_FORMAT as row_format,
+            t.TABLE_TYPE as table_type,
+            t.ENGINE as table_engine,
+            if(pks.table_name is not null, 1, 0) as has_primary_key,
+            if(t.ROW_FORMAT = 'COMPRESSED', 1, 0) as is_compressed,
+            if(pt.PARTITION_METHOD is not null, 1, 0) as is_partitioned,
+            COALESCE(pt.PARTITION_COUNT, 0) as partition_count,
+            COALESCE(idx.index_count, 0) as index_count,
+            COALESCE(idx.fulltext_index_count, 0) as fulltext_index_count,
+            COALESCE(idx.spatial_index_count, 0) as spatial_index_count
+        from information_schema.TABLES t
+            left join (
+                select TABLE_SCHEMA,
+                    TABLE_NAME,
+                    PARTITION_METHOD,
+                    SUBPARTITION_METHOD,
+                    count(1) as PARTITION_COUNT
+                from information_schema.PARTITIONS
+                where table_schema not in (
+                        'mysql',
+                        'information_schema',
+                        'performance_schema',
+                        'sys'
+                    )
+                group by TABLE_SCHEMA,
+                    TABLE_NAME,
+                    PARTITION_METHOD,
+                    SUBPARTITION_METHOD
+            ) pt on (
+                t.table_schema = pt.table_schema
+                and t.TABLE_NAME = pt.TABLE_NAME
+            )
+            left join (
+                select table_schema,
+                    TABLE_NAME
+                from information_schema.statistics
+                where table_schema not in (
+                        'mysql',
+                        'information_schema',
+                        'performance_schema',
+                        'sys'
+                    )
+                group by table_schema,
+                    TABLE_NAME,
+                    index_name
+                having SUM(
+                        if(
+                            non_unique = 0
+                            and NULLABLE != 'YES',
+                            1,
+                            0
+                        )
+                    ) = count(*)
+            ) pks on (
+                t.table_schema = pks.table_schema
+                and t.TABLE_NAME = pks.TABLE_NAME
+            )
+            left join (
+                select s.table_schema,
+                    s.table_name,
+                    count(1) as index_count,
+                    sum(
+                        if(s.INDEX_TYPE = 'FULLTEXT', 1, 0)
+                    ) as fulltext_index_count,
+                    sum(if(s.INDEX_TYPE = 'SPATIAL', 1, 0)) as spatial_index_count
+                from information_schema.STATISTICS s
+                where s.table_schema not in (
+                        'mysql',
+                        'information_schema',
+                        'performance_schema',
+                        'sys'
+                    )
+                group by s.table_schema,
+                    s.table_name
+            ) idx on (
+                t.table_schema = idx.table_schema
+                and t.TABLE_NAME = idx.TABLE_NAME
+            )
+        where t.table_schema not in (
+                'mysql',
+                'information_schema',
+                'performance_schema',
+                'sys'
+            )
+    ) user_tables;

--- a/scripts/collector/mysql/sql/users.sql
+++ b/scripts/collector/mysql/sql/users.sql
@@ -1,37 +1,36 @@
-with src as (
-    select u.host as user_host,
-        count(1) as user_count,
-        sum(if(u.authentication_string = '', 1, 0)) as user_no_authentication_string_count,
-        sum(
-            if(
-                u.host = '%'
-                or u.host = '',
-                1,
-                0
-            )
-        ) as user_no_host_count,
-        sum(
-            if(
-                u.authentication_string = '',
-                1,
-                0
-            )
-        ) as user_no_password_count,
-        sum(
-            if(
-                u.shutdown_priv = 'Y'
-                or u.super_priv = 'Y'
-                or u.reload_priv = 'Y',
-                1,
-                0
-            )
-        ) as user_with_shutdown_privs_count
-    from mysql.user u
-    group by HOST
-)
 select concat(char(34), @PKEY, char(34)) as pkey,
     concat(char(34), @DMA_SOURCE_ID, char(34)) as dma_source_id,
     concat(char(34), @DMA_MANUAL_ID, char(34)) as dma_manual_id,
     concat(char(34), user_host, char(34)) as user_host,
     user_count as user_count
-from src;
+from (
+        select u.host as user_host,
+            count(1) as user_count,
+            sum(if(u.authentication_string = '', 1, 0)) as user_no_authentication_string_count,
+            sum(
+                if(
+                    u.host = '%'
+                    or u.host = '',
+                    1,
+                    0
+                )
+            ) as user_no_host_count,
+            sum(
+                if(
+                    u.authentication_string = '',
+                    1,
+                    0
+                )
+            ) as user_no_password_count,
+            sum(
+                if(
+                    u.shutdown_priv = 'Y'
+                    or u.super_priv = 'Y'
+                    or u.reload_priv = 'Y',
+                    1,
+                    0
+                )
+            ) as user_with_shutdown_privs_count
+        from mysql.user u
+        group by HOST
+    ) src;


### PR DESCRIPTION
This PR removes all common table expressions from the MySQL collector scripts.

This enables support for older releases of MySQL and Percona