### PR TITLE
feat: column masking additions and file name masking

### DIFF
--- a/docs/user_guide/oracle/collection_masker.md
+++ b/docs/user_guide/oracle/collection_masker.md
@@ -1,8 +1,8 @@
 # Masking a collection
 
-While the collection script do not gather any data or source code, it does contain the name of schemas. If there is a requirement to obfuscate this data, there is an optional masking script included with the scripts.
+While the collection script do not gather any data or source code, it does contain the name of schemas and hostname information. If there is a requirement to obfuscate this data, there is an optional masking script included with the scripts.
 
-This script will create a key file that maps the anonymized schema name to its original name.
+This script will create a key file that maps the anonymized schema attribute to its original name.
 
 **Note** This file should is not sent with the collection script and should not be lost, as it can't be recreated.
 
@@ -26,4 +26,14 @@ options:
                         Path to search for collections.
   --output-path OUTPUT_PATH
                         Path to write masked collections.
+```
+
+## Installation Note
+
+The only requirement this script has is the `packaging` Python repository.  This is likely already installed in your environment as it is part of many core packages.
+
+However, if you receive an error related to importing this package, please run:
+
+```shell
+pip install -U packaging
 ```

--- a/docs/user_guide/oracle/collection_masker.md
+++ b/docs/user_guide/oracle/collection_masker.md
@@ -1,10 +1,10 @@
 # Masking a collection
 
-While the collection script do not gather any data or source code, it does contain the name of schemas and hostname information. If there is a requirement to obfuscate this data, there is an optional masking script included with the scripts.
+While the collection script does not gather any data or source code, it does contain the name of schemas and hostname information. If there is a requirement to obfuscate this data, there is an optional masking script included with the scripts.
 
-This script will create a key file that maps the anonymized schema attribute to its original name.
+This script will create a key file that maps the anonymized schema and hostname attributes to its original name.
 
-**Note** This file should is not sent with the collection script and should not be lost, as it can't be recreated.
+**Note** This file should not be sent with the collection and should not be lost, as it can't be recreated.
 
 ## Executing the script
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,3 +2,4 @@ bump2version
 ruff
 sqlfluff
 pre-commit
+faker

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,4 +2,3 @@ bump2version
 ruff
 sqlfluff
 pre-commit
-faker

--- a/scripts/masker/dma-collection-masker
+++ b/scripts/masker/dma-collection-masker
@@ -22,10 +22,10 @@ import sys
 import tarfile
 import zipfile as zf
 from collections import namedtuple
-from datetime import datetime
 from enum import Flag, auto
 from pathlib import Path
 from tempfile import NamedTemporaryFile, TemporaryDirectory
+from typing import Dict, List, Optional, Tuple
 
 from packaging.version import Version
 from packaging.version import parse as parse_version
@@ -181,13 +181,12 @@ class ApplicationError(Exception):
     """
 
 
-def run_masker(input_dir: Path | None = None, output_path: Path | None = None) -> None:
+def run_masker(input_dir: Optional[Path] = None, output_path: Optional[Path] = None) -> None:
     """Run Masker.
 
     Args:
-        config (Dict[str,str]): dictionary representation of the config.
-        input_dir (Path | None, optional): Path containing collections to mask. Defaults to None.
-        output_path (Path | None, optional): Path to write masked collection. Defaults to None.
+        input_dir (Optional[Path]): Path containing collections to mask. Defaults to None.
+        output_path (Optional[Path]): Path to write masked collection. Defaults to None.
     """
     with TemporaryDirectory() as temp_dir:
         work_dir = Path(temp_dir)
@@ -278,7 +277,7 @@ def _mask_file_collection_key(collection_file: Path) -> Path:
     )
 
 
-def _find_collections_to_process(search_path: Path) -> list[Path]:
+def _find_collections_to_process(search_path: Path) -> List[Path]:
     """Find collections to process.
 
     Args:
@@ -316,7 +315,7 @@ def _extract_collection(collection_file: Path, extract_path: Path) -> None:
         tf.close()
 
 
-def _find_files_referenced_by_rule(rule: DataMaskRule, search_path: Path) -> list[Path] | None:
+def _find_files_referenced_by_rule(rule: DataMaskRule, search_path: Path) -> Optional[Path]:
     """Find files referenced by data masking rule.
 
     Args:
@@ -350,8 +349,8 @@ def _find_files_referenced_by_rule(rule: DataMaskRule, search_path: Path) -> lis
 def _generate_identity_map_from_rule(
     rule: DataMaskRule,
     collection_file: Path,
-    existing_identity_map: dict[str, str] | None = None,
-) -> dict[str, str]:
+    existing_identity_map: Optional[Dict[str, str]] = None,
+) -> Dict[str, str]:
     """Generate identity map from rule.
 
     This function takes a rule and identifies all of the unique values that should be replaced within a collection.
@@ -369,7 +368,7 @@ def _generate_identity_map_from_rule(
     if existing_identity_map is None:
         existing_identity_map = {}
 
-    all_values: list[str] = list(existing_identity_map.keys())
+    all_values: List[str] = list(existing_identity_map.keys())
     collection_metadata = _metadata_from_filename(collection_file)
     column_position = rule.column_position
     if collection_metadata.script_version < Version("4.3.15") and rule.column_position < -2:
@@ -390,7 +389,7 @@ def _generate_identity_map_from_rule(
     }
 
 
-def _apply_identity_map_to_file(rule: DataMaskRule, collection_file: Path, identity_map: dict[str, str]) -> None:
+def _apply_identity_map_to_file(rule: DataMaskRule, collection_file: Path, identity_map: Dict[str, str]) -> None:
     """Apply Identity Map to File.
 
     This function takes the identity map (a dictionary that holds unique values and their masked replacement value) and applies it to a file.
@@ -418,10 +417,10 @@ def _apply_identity_map_to_file(rule: DataMaskRule, collection_file: Path, ident
 
 def _package_collection(
     collection: Path,
-    identity_map: dict[str, str],
+    identity_map: Dict[str, str],
     extract_path: Path,
     output_path: Path,
-) -> tuple[Path, Path]:
+) -> Tuple[Path, Path]:
     """Packages de-identified files.
 
     Args:

--- a/scripts/masker/dma-collection-masker
+++ b/scripts/masker/dma-collection-masker
@@ -77,9 +77,8 @@ class DMAFaker():
     ]
 
     def __init__(self) -> None:
-        self._static_hostname: str = self.hostname()
-        self._static_database_name: str = self.database_name()
-        self._static_instance_name: str = self.instance_name()
+        self._collection_key: str
+        self._date_time: str
         self._dbid: str = self._digits(length=10)
 
     def _letters(self, length: int) -> str:
@@ -87,6 +86,23 @@ class DMAFaker():
 
     def _digits(self, length: int) -> str:
         return "".join(random.choices(string.digits, k=length))
+
+    @property
+    def date_time(self) -> str:
+        return self._date_time
+
+    @date_time.setter
+    def date_time(self, value: str) -> str:
+        self._date_time = value
+
+    @property
+    def collection_key(self) -> str:
+        return self._collection_key
+
+    def set_collection_key_from_date_time(self, date_time: str) -> str:
+        if not self._date_time:
+            raise ValueError("date_time is not set")
+        self._collection_key = f"{self.hostname()}_{self.database_name()}_{self.instance_name()}_{date_time}"
 
     def database_name(self) -> str:
         return f"""db-{self._letters(length=8)}""".upper()
@@ -99,20 +115,14 @@ class DMAFaker():
         domain = f"""{self._letters(length=5)}.{random.choice(self.hostname_domains)}"""
         return f"{prefix}.{domain}"
 
-    def date_time(self) -> str:
-        return datetime.now().strftime("%m%d%y%H%M%S")
-
     def pkey(self) -> str:
-        return f"{self.hostname()}_{self.database_name()}_{self.date_time()}"
+        return f"{self.hostname()}_{self.database_name()}_{self.date_time}"
 
     def dma_source_id(self) -> str:
         return f"{self.hostname()}_{self.instance_name()}_{self._dbid}"
 
-    def collection_key_from_date_time(self, date_time: str) -> str:
-        return f"{self._static_hostname}_{self._static_database_name}_{self._static_instance_name}_{date_time}"
-
     def user_name(self) -> str:
-        return f"USER_{self._letters(length=4)}{self._digits(length=2)}"
+        return f"USER_{self._letters(length=4)}{self._digits(length=2)}".upper()
 
 
 fake = DMAFaker()
@@ -196,6 +206,8 @@ def run_masker(input_dir: Path | None = None, output_path: Path | None = None) -
 
         for collection in collections:
             collection_metadata = _metadata_from_filename(collection)
+            fake.date_time = collection_metadata.date_time
+            fake.set_collection_key_from_date_time(collection_metadata.date_time)
             identity_map: dict[str, str] = {collection_metadata.pkey: fake.pkey()}
             _extract_collection(collection, work_dir)
             for rule in DATA_MASK_CONFIG:
@@ -260,7 +272,7 @@ def _mask_file_collection_key(collection_file: Path) -> Path:
     """
     metadata = _metadata_from_filename(collection_file)
     return collection_file.with_stem(
-        collection_file.stem.replace(metadata.collection_key, fake.collection_key_from_date_time(metadata.date_time))
+        collection_file.stem.replace(metadata.collection_key, fake.collection_key)
     )
 
 

--- a/scripts/masker/dma-collection-masker
+++ b/scripts/masker/dma-collection-masker
@@ -22,9 +22,17 @@ import sys
 import tarfile
 import zipfile as zf
 from collections import namedtuple
+from datetime import datetime
+from enum import Flag, auto
 from pathlib import Path
 from tempfile import NamedTemporaryFile, TemporaryDirectory
-from typing import Dict, List, Optional, Tuple
+
+from faker import Faker
+from faker.providers.internet import ElementsType
+from faker.providers.internet import Provider as InternetProvider
+from faker.providers.lorem.en_US import Provider as LoremProvider
+from packaging.version import Version
+from packaging.version import parse as parse_version
 
 __all__ = [
     "ApplicationError",
@@ -40,29 +48,93 @@ logger = logging.getLogger(__name__)
 here = Path(__file__).parent
 
 DataMaskRule = namedtuple("DataMaskRule", ["mask_type", "table_name", "column_position", "missing_ok"])
+FileMetadata = namedtuple(
+    "FileMetadata",
+    ["script_version", "host_name", "database_name", "instance_name", "date_time", "pkey", "collection_key"],
+)
+
+
+class DMAFakerProvider(LoremProvider, InternetProvider):
+    """Custom Faker provider to provide masked values"""
+
+    user_name_formats: ElementsType[str] = ("USER_{{first_name}}##",)
+
+    def __init__(self, *args, **kwargs) -> None:
+        super().__init__(*args, **kwargs)
+        self._static_hostname: str = self.hostname()
+        self._static_database_name: str = self.database_name()
+        self._static_instance_name: str = self.instance_name()
+        self._dbid: str = "".join(random.choices(string.digits, k=10))
+
+    def database_name(self) -> str:
+        return f"""db-{self.text(max_nb_chars=8).rstrip(".")}""".upper()
+
+    def instance_name(self) -> str:
+        return f"""inst-{self.text(max_nb_chars=8).rstrip(".")}""".upper()
+
+    def date_time(self) -> str:
+        return datetime.now().strftime("%m%d%y%H%M%S")
+
+    def pkey(self) -> str:
+        return f"{self.hostname()}_{self.database_name()}_{self.date_time()}"
+
+    def dma_source_id(self) -> str:
+        return f"{self.hostname()}_{self.instance_name()}_{self._dbid}"
+
+    def collection_key_from_date_time(self, date_time: str) -> str:
+        return f"{self._static_hostname}_{self._static_database_name}_{self._static_instance_name}_{date_time}"
+
+    def user_name(self) -> str:
+        return super().user_name().upper()
+
+
+fake = Faker()
+fake.add_provider(DMAFakerProvider)
+
+
+class DataMaskTypes(Flag):
+    SCHEMA_NAME = auto()
+    PKEY = auto()
+    DMA_SOURCE_ID = auto()
+    INSTANCE_NAME = auto()
+    HOST_NAME = auto()
+    DATABASE_NAME = auto()
 
 
 DATA_MASK_CONFIG = [
-    DataMaskRule(mask_type="Schema Name", table_name="columntypes", column_position=2, missing_ok=True),
-    DataMaskRule(mask_type="Schema Name", table_name="compressbytype", column_position=2, missing_ok=True),
-    DataMaskRule(mask_type="Schema Name", table_name="datatypes", column_position=2, missing_ok=True),
-    DataMaskRule(mask_type="Schema Name", table_name="dbobjectnames", column_position=2, missing_ok=True),
-    DataMaskRule(mask_type="Schema Name", table_name="dbobjects", column_position=2, missing_ok=True),
-    DataMaskRule(mask_type="Schema Name", table_name="dtlsourcecode", column_position=2, missing_ok=True),
-    DataMaskRule(mask_type="Schema Name", table_name="exttab", column_position=2, missing_ok=True),
-    DataMaskRule(mask_type="Schema Name", table_name="indextypedtl", column_position=2, missing_ok=True),
-    DataMaskRule(mask_type="Schema Name", table_name="indextypes", column_position=2, missing_ok=True),
-    DataMaskRule(mask_type="Schema Name", table_name="lobsizing", column_position=2, missing_ok=True),
-    DataMaskRule(mask_type="Schema Name", table_name="mviewtypes", column_position=2, missing_ok=True),
-    DataMaskRule(mask_type="Schema Name", table_name="sourcecode", column_position=2, missing_ok=True),
-    DataMaskRule(mask_type="Schema Name", table_name="tableconstraints", column_position=2, missing_ok=True),
-    DataMaskRule(mask_type="Schema Name", table_name="tablesnopk", column_position=2, missing_ok=True),
-    DataMaskRule(mask_type="Schema Name", table_name="tabletypedtl", column_position=2, missing_ok=True),
-    DataMaskRule(mask_type="Schema Name", table_name="tabletypes", column_position=2, missing_ok=True),
-    DataMaskRule(mask_type="Schema Name", table_name="triggers", column_position=2, missing_ok=True),
-    DataMaskRule(mask_type="Schema Name", table_name="usedspacedetails", column_position=2, missing_ok=True),
-    DataMaskRule(mask_type="Schema Name", table_name="usrsegatt", column_position=2, missing_ok=True),
-    DataMaskRule(mask_type="Schema Name", table_name="users", column_position=2, missing_ok=True),
+    DataMaskRule(mask_type=DataMaskTypes.PKEY, table_name="*", column_position=0, missing_ok=False),
+    DataMaskRule(mask_type=DataMaskTypes.DMA_SOURCE_ID, table_name="*", column_position=-2, missing_ok=False),
+    DataMaskRule(mask_type=DataMaskTypes.SCHEMA_NAME, table_name="columntypes", column_position=2, missing_ok=True),
+    DataMaskRule(mask_type=DataMaskTypes.SCHEMA_NAME, table_name="compressbytype", column_position=2, missing_ok=True),
+    DataMaskRule(mask_type=DataMaskTypes.SCHEMA_NAME, table_name="datatypes", column_position=2, missing_ok=True),
+    DataMaskRule(mask_type=DataMaskTypes.SCHEMA_NAME, table_name="dbobjectnames", column_position=2, missing_ok=True),
+    DataMaskRule(mask_type=DataMaskTypes.SCHEMA_NAME, table_name="dbobjects", column_position=2, missing_ok=True),
+    DataMaskRule(mask_type=DataMaskTypes.SCHEMA_NAME, table_name="dtlsourcecode", column_position=2, missing_ok=True),
+    DataMaskRule(mask_type=DataMaskTypes.SCHEMA_NAME, table_name="exttab", column_position=2, missing_ok=True),
+    DataMaskRule(mask_type=DataMaskTypes.SCHEMA_NAME, table_name="indextypedtl", column_position=2, missing_ok=True),
+    DataMaskRule(mask_type=DataMaskTypes.SCHEMA_NAME, table_name="indextypes", column_position=2, missing_ok=True),
+    DataMaskRule(mask_type=DataMaskTypes.SCHEMA_NAME, table_name="lobsizing", column_position=2, missing_ok=True),
+    DataMaskRule(mask_type=DataMaskTypes.SCHEMA_NAME, table_name="mviewtypes", column_position=2, missing_ok=True),
+    DataMaskRule(mask_type=DataMaskTypes.SCHEMA_NAME, table_name="sourcecode", column_position=2, missing_ok=True),
+    DataMaskRule(
+        mask_type=DataMaskTypes.SCHEMA_NAME, table_name="tableconstraints", column_position=2, missing_ok=True
+    ),
+    DataMaskRule(mask_type=DataMaskTypes.SCHEMA_NAME, table_name="tablesnopk", column_position=2, missing_ok=True),
+    DataMaskRule(mask_type=DataMaskTypes.SCHEMA_NAME, table_name="tabletypedtl", column_position=2, missing_ok=True),
+    DataMaskRule(mask_type=DataMaskTypes.SCHEMA_NAME, table_name="tabletypes", column_position=2, missing_ok=True),
+    DataMaskRule(mask_type=DataMaskTypes.SCHEMA_NAME, table_name="triggers", column_position=2, missing_ok=True),
+    DataMaskRule(
+        mask_type=DataMaskTypes.SCHEMA_NAME, table_name="usedspacedetails", column_position=2, missing_ok=True
+    ),
+    DataMaskRule(mask_type=DataMaskTypes.SCHEMA_NAME, table_name="usrsegatt", column_position=2, missing_ok=True),
+    DataMaskRule(mask_type=DataMaskTypes.SCHEMA_NAME, table_name="users", column_position=2, missing_ok=True),
+    DataMaskRule(mask_type=DataMaskTypes.INSTANCE_NAME, table_name="dbinstances", column_position=2, missing_ok=True),
+    DataMaskRule(mask_type=DataMaskTypes.HOST_NAME, table_name="dbinstances", column_position=3, missing_ok=True),
+    DataMaskRule(mask_type=DataMaskTypes.DATABASE_NAME, table_name="dbsummary", column_position=2, missing_ok=True),
+    DataMaskRule(mask_type=DataMaskTypes.DATABASE_NAME, table_name="dbsummary", column_position=-3, missing_ok=True),
+    DataMaskRule(mask_type=DataMaskTypes.DATABASE_NAME, table_name="pdbsinfo", column_position=3, missing_ok=True),
+    DataMaskRule(mask_type=DataMaskTypes.DATABASE_NAME, table_name="pdbsopenmode", column_position=2, missing_ok=True),
+    DataMaskRule(mask_type=DataMaskTypes.HOST_NAME, table_name="sourceconn", column_position=6, missing_ok=True),
 ]
 
 
@@ -73,7 +145,7 @@ class ApplicationError(Exception):
     """
 
 
-def run_masker(input_dir: Optional[Path] = None, output_path: Optional[Path] = None) -> None:
+def run_masker(input_dir: Path | None = None, output_path: Path | None = None) -> None:
     """Run Masker.
 
     Args:
@@ -87,21 +159,25 @@ def run_masker(input_dir: Optional[Path] = None, output_path: Optional[Path] = N
         input_dir = input_dir if input_dir else Path("input")
         output_path = output_path if output_path else Path("masked")
 
-        for dir_name in {input_dir, output_path}:
+        for dir_name in (input_dir, output_path):
             dir_name.mkdir(parents=True, exist_ok=True)
 
         collections = _find_collections_to_process(input_dir)
         if len(collections) == 0:
             logger.info("No collections found in location %s", str(input_dir))
             logger.info("Exiting...")
-            exit(1)
+            sys.exit(1)
 
         for collection in collections:
-            identity_map: Dict[str, str] = {}
+            collection_metadata = _metadata_from_filename(collection)
+            identity_map: dict[str, str] = {collection_metadata.pkey: fake.pkey()}
             _extract_collection(collection, work_dir)
             for rule in DATA_MASK_CONFIG:
-                collection_file = _find_file_referenced_by_rule(rule, work_dir)
-                if collection_file:
+                if rule.mask_type == DataMaskTypes.DMA_SOURCE_ID and collection_metadata.script_version < Version(
+                    "4.3.15"
+                ):
+                    continue
+                for collection_file in _find_files_referenced_by_rule(rule, work_dir):
                     identity_map = _generate_identity_map_from_rule(rule, collection_file, identity_map)
                     _apply_identity_map_to_file(rule, collection_file, identity_map)
             logger.info("Completed work on %s", collection.stem)
@@ -122,16 +198,56 @@ def run_masker(input_dir: Optional[Path] = None, output_path: Optional[Path] = N
         )
 
 
-def _find_collections_to_process(search_path: Path) -> List[Path]:
+def _metadata_from_filename(collection_file: Path) -> FileMetadata:
+    """Return metadata by parsing the collection file name.
+
+    Args:
+        collection_file (Path): The path of the file to read.
+
+    Raises:
+        ApplicationError: Raised when parsing metadata fails.
+
+    Returns:
+        FileMetadata: namedtuple containing metadata attributes.
+    """
+    try:
+        meta_values = collection_file.stem.split("__", maxsplit=2)[-1].split("_")[1:6]
+        meta_values[0] = parse_version(meta_values[0])
+        meta_values.append("_".join(meta_values[1:3] + [meta_values[4]]))  # pkey
+        meta_values.append("_".join(meta_values[1:5]))  # collection_key
+        metadata = FileMetadata(*meta_values)
+    except (ValueError, IndexError, TypeError) as e:
+        msg = f"Could not determine metadata from file {collection_file.stem}"
+        raise ApplicationError(msg) from e
+    else:
+        return metadata
+
+
+def _mask_file_collection_key(collection_file: Path) -> Path:
+    """Return a file with a masked collection key stem.
+
+    Args:
+        collection_file (Path): The path of the file to mask.
+
+    Returns:
+        Path: masked collection key file path.
+    """
+    metadata = _metadata_from_filename(collection_file)
+    return collection_file.with_stem(
+        collection_file.stem.replace(metadata.collection_key, fake.collection_key_from_date_time(metadata.date_time))
+    )
+
+
+def _find_collections_to_process(search_path: Path) -> list[Path]:
     """Find collections to process.
 
     Args:
-        search_path (Path): The path to search for collections
+        search_path (Path): The path to search for collections.
 
         Check for zip and gzip files and return list of paths.
 
     Returns:
-        List[Path]: list of files found matching the collection pattern
+        List[Path]: list of files found matching the collection pattern.
     """
     file_list = (
         set(search_path.glob("opdb_oracle_*.zip"))
@@ -160,37 +276,42 @@ def _extract_collection(collection_file: Path, extract_path: Path) -> None:
         tf.close()
 
 
-def _find_file_referenced_by_rule(rule: DataMaskRule, search_path: Path) -> Optional[Path]:
-    """Find file referenced by data masking rule.
+def _find_files_referenced_by_rule(rule: DataMaskRule, search_path: Path) -> list[Path] | None:
+    """Find files referenced by data masking rule.
 
     Args:
         rule (DataMaskRule): The data masking rule to apply.
         search_path (Path): The search path to look for collection csv files.
 
     Raises:
-        ApplicationError: Raised when no matching file is found.
-        ApplicationError: Raise when more than 1 matching files are found.
+        ApplicationError: Raised when no matching files are found.
+        ApplicationError: Raise when more than 1 matching files are found if no wildcard search.
 
     Returns:
-       Optional[Path]: If the file was found, the file.  Else None.
+       Optional[list[Path]]: If the files were found, the files.  Else None.
     """
-    matched_file = list(search_path.glob(f"opdb__{rule.table_name}__*.csv"))
+    matched_file = list(
+        set(search_path.glob(f"opdb__{rule.table_name}__*.csv")).difference(search_path.glob("opdb__defines__*.csv"))
+    )
     if not matched_file and not rule.missing_ok:
-        raise ApplicationError(f"Could not find a file to match for {rule.table_name}")
+        msg = f"Could not find a file to match for {rule.table_name}"
+        raise ApplicationError(msg)
     if matched_file and not rule.missing_ok and len(matched_file) == 0:
-        raise ApplicationError(f"Could not find a file to match for {rule.table_name}")
-    if matched_file and len(matched_file) > 1:
-        raise ApplicationError(f"Found too many files when searching for {rule.table_name}.  Found {matched_file}")
-    if matched_file and len(matched_file) == 1:
-        return matched_file[0]
+        msg = f"Could not find a file to match for {rule.table_name}"
+        raise ApplicationError(msg)
+    if matched_file and len(matched_file) > 1 and rule.table_name != "*":
+        msg = f"Found too many files when searching for {rule.table_name}.  Found {matched_file}"
+        raise ApplicationError(msg)
+    if matched_file and len(matched_file) != 0:
+        return matched_file
     return None
 
 
 def _generate_identity_map_from_rule(
     rule: DataMaskRule,
     collection_file: Path,
-    existing_identity_map: Optional[Dict[str, str]] = None,
-) -> Dict[str, str]:
+    existing_identity_map: dict[str, str] | None = None,
+) -> dict[str, str]:
     """Generate identity map from rule.
 
     This function takes a rule and identifies all of the unique values that should be replaced within a collection.
@@ -208,7 +329,7 @@ def _generate_identity_map_from_rule(
     if existing_identity_map is None:
         existing_identity_map = {}
 
-    all_values: List[str] = list(existing_identity_map.keys())
+    all_values: list[str] = list(existing_identity_map.keys())
     with collection_file.open(mode="r", encoding="utf-8") as f:
         data_to_mask = csv.reader(f, delimiter="|", quotechar='"')
         for rn, row in enumerate(data_to_mask):
@@ -216,16 +337,32 @@ def _generate_identity_map_from_rule(
                 # Get the value from column to mask
                 all_values.append(row[rule.column_position])
     unique_values = list(dict.fromkeys(all_values))
+    match rule.mask_type:
+        case DataMaskTypes.SCHEMA_NAME:
+            masked_value = fake.user_name
+        case DataMaskTypes.HOST_NAME:
+            masked_value = fake.hostname
+        case DataMaskTypes.INSTANCE_NAME:
+            masked_value = fake.instance_name
+        case DataMaskTypes.DATABASE_NAME:
+            masked_value = fake.database_name
+        case DataMaskTypes.PKEY:
+            masked_value = fake.pkey
+        case DataMaskTypes.DMA_SOURCE_ID:
+            masked_value = fake.dma_source_id
+        case _:
+            msg = f"Unsupported masking type: {rule.mask_type}"
+            raise ApplicationError(msg)
     return {
         value: existing_identity_map.get(
             value,
-            f"USER_{''.join(random.choices(string.ascii_lowercase + string.digits, k=3)).upper()}",
+            masked_value(),
         )
         for value in unique_values
     }
 
 
-def _apply_identity_map_to_file(rule: DataMaskRule, collection_file: Path, identity_map: Dict[str, str]) -> None:
+def _apply_identity_map_to_file(rule: DataMaskRule, collection_file: Path, identity_map: dict[str, str]) -> None:
     """Apply Identity Map to File.
 
     This function takes the identity map (a dictionary that holds unique values and their masked replacement value) and applies it to a file.
@@ -249,10 +386,10 @@ def _apply_identity_map_to_file(rule: DataMaskRule, collection_file: Path, ident
 
 def _package_collection(
     collection: Path,
-    identity_map: Dict[str, str],
+    identity_map: dict[str, str],
     extract_path: Path,
     output_path: Path,
-) -> Tuple[Path, Path]:
+) -> tuple[Path, Path]:
     """Packages de-identified files.
 
     Args:
@@ -264,24 +401,27 @@ def _package_collection(
     Returns:
         Tuple[Path, Path]: The new key file and archive file.
     """
-    file_stem = collection.stem if collection.stem.endswith("zip") else collection.stem.rstrip(".tar")
+    masked_collection_file = _mask_file_collection_key(collection)
+    identity_map[collection.name] = masked_collection_file.name
 
-    logger.info("Zipping %s", collection.stem)
-    archive_file = Path(output_path / f"{file_stem}.zip")
-    key_file = Path(collection.parent / f"{file_stem}.key")
+    logger.info("Zipping %s", masked_collection_file.stem)
+    archive_file = Path(output_path / f"{masked_collection_file.stem}.zip")
+    key_file = Path(collection.parent / f"{masked_collection_file.stem}.key")
     matched_files = (
         list(extract_path.glob("*.csv")) + list(extract_path.glob("*.log")) + list(extract_path.glob("*.txt"))
     )
     with zf.ZipFile(archive_file, "w") as f:
         for matched_file in matched_files:
-            f.write(matched_file, f"{matched_file.stem}{matched_file.suffix}")
+            masked_file = _mask_file_collection_key(matched_file)
+            identity_map[matched_file.name] = masked_file.name
+            f.write(matched_file, f"{masked_file.stem}{masked_file.suffix}")
     with key_file.open(mode="w", encoding="utf-8") as f:
         f.write(
             f"Use this file to map the masked values to the original values in collection {archive_file.stem}.zip\n"
         )
         f.write("ORIGINAL,MASKED\n")
         csv_writer = csv.writer(f, delimiter="|", quotechar='"')
-        csv_writer.writerows(identity_map.items())
+        csv_writer.writerows(sorted(identity_map.items()))
     return key_file, archive_file
 
 
@@ -307,7 +447,8 @@ def main() -> None:
         p = Path(path)
         if p.exists() and p.is_dir() and path is not None:
             return path
-        raise argparse.ArgumentTypeError(f"collection-path {path} is not a valid path")
+        msg = f"collection-path {path} is not a valid path"
+        raise argparse.ArgumentTypeError(msg)
 
     parser = argparse.ArgumentParser(description="Google Database Migration Assessment - Collection Masking Script")
     parser.add_argument(
@@ -329,7 +470,8 @@ def main() -> None:
     )
     args = parser.parse_args(args=None if sys.argv[1:] else ["--help"])
     if Path(args.collection_path) == Path(args.output_path):
-        raise argparse.ArgumentTypeError("output-path must not be the same path as collection-path")
+        msg = "output-path must not be the same path as collection-path"
+        raise argparse.ArgumentTypeError(msg)
     level = args.verbose
     if level == 0:
         level = logging.ERROR

--- a/scripts/masker/dma-collection-masker
+++ b/scripts/masker/dma-collection-masker
@@ -215,9 +215,11 @@ def run_masker(input_dir: Path | None = None, output_path: Path | None = None) -
                     "4.3.15"
                 ):
                     continue
-                for collection_file in _find_files_referenced_by_rule(rule, work_dir):
-                    identity_map = _generate_identity_map_from_rule(rule, collection_file, identity_map)
-                    _apply_identity_map_to_file(rule, collection_file, identity_map)
+                collection_files = _find_files_referenced_by_rule(rule, work_dir)
+                if collection_files:
+                    for collection_file in collection_files:
+                        identity_map = _generate_identity_map_from_rule(rule, collection_file, identity_map)
+                        _apply_identity_map_to_file(rule, collection_file, identity_map)
             logger.info("Completed work on %s", collection.stem)
             _collection_key_file, _new_collection_archive = _package_collection(
                 collection, identity_map, work_dir, output_path
@@ -368,12 +370,16 @@ def _generate_identity_map_from_rule(
         existing_identity_map = {}
 
     all_values: list[str] = list(existing_identity_map.keys())
+    collection_metadata = _metadata_from_filename(collection_file)
+    column_position = rule.column_position
+    if collection_metadata.script_version < Version("4.3.15") and rule.column_position < -2:
+        column_position += 2
     with collection_file.open(mode="r", encoding="utf-8") as f:
         data_to_mask = csv.reader(f, delimiter="|", quotechar='"')
         for rn, row in enumerate(data_to_mask):
             if rn > 0:
                 # Get the value from column to mask
-                all_values.append(row[rule.column_position])
+                all_values.append(row[column_position])
     unique_values = list(dict.fromkeys(all_values))
     return {
         value: existing_identity_map.get(
@@ -399,9 +405,13 @@ def _apply_identity_map_to_file(rule: DataMaskRule, collection_file: Path, ident
     with collection_file.open(mode="r", encoding="utf-8") as f, NamedTemporaryFile(mode="w", delete=False) as t:
         data_to_mask = csv.reader(f, delimiter="|", quotechar='"')
         temp_file = csv.writer(t, delimiter="|", quotechar='"')
+        collection_metadata = _metadata_from_filename(collection_file)
+        column_position = rule.column_position
+        if collection_metadata.script_version < Version("4.3.15") and rule.column_position < -2:
+            column_position += 2
         for rn, row in enumerate(data_to_mask):
             if rn > 0:
-                row[rule.column_position] = identity_map.get(row[rule.column_position], "~~UNMAPPED~~")
+                row[column_position] = identity_map.get(row[column_position], "~~UNMAPPED~~")
             temp_file.writerow(row)
         shutil.move(t.name, collection_file)
 

--- a/scripts/masker/dma-collection-masker
+++ b/scripts/masker/dma-collection-masker
@@ -92,7 +92,7 @@ class DMAFaker():
         return self._date_time
 
     @date_time.setter
-    def date_time(self, value: str) -> str:
+    def date_time(self, value: str) -> None:
         self._date_time = value
 
     @property

--- a/scripts/masker/dma-collection-masker
+++ b/scripts/masker/dma-collection-masker
@@ -99,7 +99,7 @@ class DMAFaker():
     def collection_key(self) -> str:
         return self._collection_key
 
-    def set_collection_key_from_date_time(self, date_time: str) -> str:
+    def set_collection_key_from_date_time(self, date_time: str) -> None:
         if not self._date_time:
             raise ValueError("date_time is not set")
         self._collection_key = f"{self.hostname()}_{self.database_name()}_{self.instance_name()}_{date_time}"

--- a/scripts/masker/dma-collection-masker
+++ b/scripts/masker/dma-collection-masker
@@ -47,7 +47,7 @@ logger = logging.getLogger(__name__)
 
 here = Path(__file__).parent
 
-DataMaskRule = namedtuple("DataMaskRule", ["mask_type", "table_name", "column_position", "missing_ok"])
+DataMaskRule = namedtuple("DataMaskRule", ["mask_type", "table_name", "column_position", "missing_ok", "fake_function"])
 FileMetadata = namedtuple(
     "FileMetadata",
     ["script_version", "host_name", "database_name", "instance_name", "date_time", "pkey", "collection_key"],
@@ -102,39 +102,39 @@ class DataMaskTypes(Flag):
 
 
 DATA_MASK_CONFIG = [
-    DataMaskRule(mask_type=DataMaskTypes.PKEY, table_name="*", column_position=0, missing_ok=False),
-    DataMaskRule(mask_type=DataMaskTypes.DMA_SOURCE_ID, table_name="*", column_position=-2, missing_ok=False),
-    DataMaskRule(mask_type=DataMaskTypes.SCHEMA_NAME, table_name="columntypes", column_position=2, missing_ok=True),
-    DataMaskRule(mask_type=DataMaskTypes.SCHEMA_NAME, table_name="compressbytype", column_position=2, missing_ok=True),
-    DataMaskRule(mask_type=DataMaskTypes.SCHEMA_NAME, table_name="datatypes", column_position=2, missing_ok=True),
-    DataMaskRule(mask_type=DataMaskTypes.SCHEMA_NAME, table_name="dbobjectnames", column_position=2, missing_ok=True),
-    DataMaskRule(mask_type=DataMaskTypes.SCHEMA_NAME, table_name="dbobjects", column_position=2, missing_ok=True),
-    DataMaskRule(mask_type=DataMaskTypes.SCHEMA_NAME, table_name="dtlsourcecode", column_position=2, missing_ok=True),
-    DataMaskRule(mask_type=DataMaskTypes.SCHEMA_NAME, table_name="exttab", column_position=2, missing_ok=True),
-    DataMaskRule(mask_type=DataMaskTypes.SCHEMA_NAME, table_name="indextypedtl", column_position=2, missing_ok=True),
-    DataMaskRule(mask_type=DataMaskTypes.SCHEMA_NAME, table_name="indextypes", column_position=2, missing_ok=True),
-    DataMaskRule(mask_type=DataMaskTypes.SCHEMA_NAME, table_name="lobsizing", column_position=2, missing_ok=True),
-    DataMaskRule(mask_type=DataMaskTypes.SCHEMA_NAME, table_name="mviewtypes", column_position=2, missing_ok=True),
-    DataMaskRule(mask_type=DataMaskTypes.SCHEMA_NAME, table_name="sourcecode", column_position=2, missing_ok=True),
+    DataMaskRule(mask_type=DataMaskTypes.PKEY, table_name="*", column_position=0, missing_ok=False, fake_function=fake.pkey),
+    DataMaskRule(mask_type=DataMaskTypes.DMA_SOURCE_ID, table_name="*", column_position=-2, missing_ok=False, fake_function=fake.dma_source_id),
+    DataMaskRule(mask_type=DataMaskTypes.SCHEMA_NAME, table_name="columntypes", column_position=2, missing_ok=True, fake_function=fake.user_name),
+    DataMaskRule(mask_type=DataMaskTypes.SCHEMA_NAME, table_name="compressbytype", column_position=2, missing_ok=True, fake_function=fake.user_name),
+    DataMaskRule(mask_type=DataMaskTypes.SCHEMA_NAME, table_name="datatypes", column_position=2, missing_ok=True, fake_function=fake.user_name),
+    DataMaskRule(mask_type=DataMaskTypes.SCHEMA_NAME, table_name="dbobjectnames", column_position=2, missing_ok=True, fake_function=fake.user_name),
+    DataMaskRule(mask_type=DataMaskTypes.SCHEMA_NAME, table_name="dbobjects", column_position=2, missing_ok=True, fake_function=fake.user_name),
+    DataMaskRule(mask_type=DataMaskTypes.SCHEMA_NAME, table_name="dtlsourcecode", column_position=2, missing_ok=True, fake_function=fake.user_name),
+    DataMaskRule(mask_type=DataMaskTypes.SCHEMA_NAME, table_name="exttab", column_position=2, missing_ok=True, fake_function=fake.user_name),
+    DataMaskRule(mask_type=DataMaskTypes.SCHEMA_NAME, table_name="indextypedtl", column_position=2, missing_ok=True, fake_function=fake.user_name),
+    DataMaskRule(mask_type=DataMaskTypes.SCHEMA_NAME, table_name="indextypes", column_position=2, missing_ok=True, fake_function=fake.user_name),
+    DataMaskRule(mask_type=DataMaskTypes.SCHEMA_NAME, table_name="lobsizing", column_position=2, missing_ok=True, fake_function=fake.user_name),
+    DataMaskRule(mask_type=DataMaskTypes.SCHEMA_NAME, table_name="mviewtypes", column_position=2, missing_ok=True, fake_function=fake.user_name),
+    DataMaskRule(mask_type=DataMaskTypes.SCHEMA_NAME, table_name="sourcecode", column_position=2, missing_ok=True, fake_function=fake.user_name),
     DataMaskRule(
-        mask_type=DataMaskTypes.SCHEMA_NAME, table_name="tableconstraints", column_position=2, missing_ok=True
+        mask_type=DataMaskTypes.SCHEMA_NAME, table_name="tableconstraints", column_position=2, missing_ok=True, fake_function=fake.user_name
     ),
-    DataMaskRule(mask_type=DataMaskTypes.SCHEMA_NAME, table_name="tablesnopk", column_position=2, missing_ok=True),
-    DataMaskRule(mask_type=DataMaskTypes.SCHEMA_NAME, table_name="tabletypedtl", column_position=2, missing_ok=True),
-    DataMaskRule(mask_type=DataMaskTypes.SCHEMA_NAME, table_name="tabletypes", column_position=2, missing_ok=True),
-    DataMaskRule(mask_type=DataMaskTypes.SCHEMA_NAME, table_name="triggers", column_position=2, missing_ok=True),
+    DataMaskRule(mask_type=DataMaskTypes.SCHEMA_NAME, table_name="tablesnopk", column_position=2, missing_ok=True, fake_function=fake.user_name),
+    DataMaskRule(mask_type=DataMaskTypes.SCHEMA_NAME, table_name="tabletypedtl", column_position=2, missing_ok=True, fake_function=fake.user_name),
+    DataMaskRule(mask_type=DataMaskTypes.SCHEMA_NAME, table_name="tabletypes", column_position=2, missing_ok=True, fake_function=fake.user_name),
+    DataMaskRule(mask_type=DataMaskTypes.SCHEMA_NAME, table_name="triggers", column_position=2, missing_ok=True, fake_function=fake.user_name),
     DataMaskRule(
-        mask_type=DataMaskTypes.SCHEMA_NAME, table_name="usedspacedetails", column_position=2, missing_ok=True
+        mask_type=DataMaskTypes.SCHEMA_NAME, table_name="usedspacedetails", column_position=2, missing_ok=True, fake_function=fake.user_name
     ),
-    DataMaskRule(mask_type=DataMaskTypes.SCHEMA_NAME, table_name="usrsegatt", column_position=2, missing_ok=True),
-    DataMaskRule(mask_type=DataMaskTypes.SCHEMA_NAME, table_name="users", column_position=2, missing_ok=True),
-    DataMaskRule(mask_type=DataMaskTypes.INSTANCE_NAME, table_name="dbinstances", column_position=2, missing_ok=True),
-    DataMaskRule(mask_type=DataMaskTypes.HOST_NAME, table_name="dbinstances", column_position=3, missing_ok=True),
-    DataMaskRule(mask_type=DataMaskTypes.DATABASE_NAME, table_name="dbsummary", column_position=2, missing_ok=True),
-    DataMaskRule(mask_type=DataMaskTypes.DATABASE_NAME, table_name="dbsummary", column_position=-3, missing_ok=True),
-    DataMaskRule(mask_type=DataMaskTypes.DATABASE_NAME, table_name="pdbsinfo", column_position=3, missing_ok=True),
-    DataMaskRule(mask_type=DataMaskTypes.DATABASE_NAME, table_name="pdbsopenmode", column_position=2, missing_ok=True),
-    DataMaskRule(mask_type=DataMaskTypes.HOST_NAME, table_name="sourceconn", column_position=6, missing_ok=True),
+    DataMaskRule(mask_type=DataMaskTypes.SCHEMA_NAME, table_name="usrsegatt", column_position=2, missing_ok=True, fake_function=fake.user_name),
+    DataMaskRule(mask_type=DataMaskTypes.SCHEMA_NAME, table_name="users", column_position=2, missing_ok=True, fake_function=fake.user_name),
+    DataMaskRule(mask_type=DataMaskTypes.INSTANCE_NAME, table_name="dbinstances", column_position=2, missing_ok=True, fake_function=fake.instance_name),
+    DataMaskRule(mask_type=DataMaskTypes.HOST_NAME, table_name="dbinstances", column_position=3, missing_ok=True, fake_function=fake.hostname),
+    DataMaskRule(mask_type=DataMaskTypes.DATABASE_NAME, table_name="dbsummary", column_position=2, missing_ok=True, fake_function=fake.database_name),
+    DataMaskRule(mask_type=DataMaskTypes.DATABASE_NAME, table_name="dbsummary", column_position=-3, missing_ok=True, fake_function=fake.database_name),
+    DataMaskRule(mask_type=DataMaskTypes.DATABASE_NAME, table_name="pdbsinfo", column_position=3, missing_ok=True, fake_function=fake.database_name),
+    DataMaskRule(mask_type=DataMaskTypes.DATABASE_NAME, table_name="pdbsopenmode", column_position=2, missing_ok=True, fake_function=fake.database_name),
+    DataMaskRule(mask_type=DataMaskTypes.HOST_NAME, table_name="sourceconn", column_position=6, missing_ok=True, fake_function=fake.hostname),
 ]
 
 
@@ -337,26 +337,10 @@ def _generate_identity_map_from_rule(
                 # Get the value from column to mask
                 all_values.append(row[rule.column_position])
     unique_values = list(dict.fromkeys(all_values))
-    match rule.mask_type:
-        case DataMaskTypes.SCHEMA_NAME:
-            masked_value = fake.user_name
-        case DataMaskTypes.HOST_NAME:
-            masked_value = fake.hostname
-        case DataMaskTypes.INSTANCE_NAME:
-            masked_value = fake.instance_name
-        case DataMaskTypes.DATABASE_NAME:
-            masked_value = fake.database_name
-        case DataMaskTypes.PKEY:
-            masked_value = fake.pkey
-        case DataMaskTypes.DMA_SOURCE_ID:
-            masked_value = fake.dma_source_id
-        case _:
-            msg = f"Unsupported masking type: {rule.mask_type}"
-            raise ApplicationError(msg)
     return {
         value: existing_identity_map.get(
             value,
-            masked_value(),
+            rule.fake_function(),
         )
         for value in unique_values
     }

--- a/scripts/masker/dma-collection-masker
+++ b/scripts/masker/dma-collection-masker
@@ -27,10 +27,6 @@ from enum import Flag, auto
 from pathlib import Path
 from tempfile import NamedTemporaryFile, TemporaryDirectory
 
-from faker import Faker
-from faker.providers.internet import ElementsType
-from faker.providers.internet import Provider as InternetProvider
-from faker.providers.lorem.en_US import Provider as LoremProvider
 from packaging.version import Version
 from packaging.version import parse as parse_version
 
@@ -54,23 +50,54 @@ FileMetadata = namedtuple(
 )
 
 
-class DMAFakerProvider(LoremProvider, InternetProvider):
-    """Custom Faker provider to provide masked values"""
+class DMAFaker():
+    """Fake data provider to provide masked values"""
 
-    user_name_formats: ElementsType[str] = ("USER_{{first_name}}##",)
+    hostname_prefixes: list[str] = [
+        "db",
+        "srv",
+        "desktop",
+        "laptop",
+        "lt",
+        "email",
+        "web",
+    ]
 
-    def __init__(self, *args, **kwargs) -> None:
-        super().__init__(*args, **kwargs)
+    hostname_domains: list[str] = [
+        "com",
+        "com",
+        "com",
+        "com",
+        "com",
+        "com",
+        "biz",
+        "info",
+        "net",
+        "org",
+    ]
+
+    def __init__(self) -> None:
         self._static_hostname: str = self.hostname()
         self._static_database_name: str = self.database_name()
         self._static_instance_name: str = self.instance_name()
-        self._dbid: str = "".join(random.choices(string.digits, k=10))
+        self._dbid: str = self._digits(length=10)
+
+    def _letters(self, length: int) -> str:
+        return "".join(random.choices(string.ascii_lowercase, k=length))
+
+    def _digits(self, length: int) -> str:
+        return "".join(random.choices(string.digits, k=length))
 
     def database_name(self) -> str:
-        return f"""db-{self.text(max_nb_chars=8).rstrip(".")}""".upper()
+        return f"""db-{self._letters(length=8)}""".upper()
 
     def instance_name(self) -> str:
-        return f"""inst-{self.text(max_nb_chars=8).rstrip(".")}""".upper()
+        return f"""inst-{self._letters(length=8)}""".upper()
+
+    def hostname(self) -> str:
+        prefix = f"""{random.choice(self.hostname_prefixes)}-{self._digits(length=2)}"""
+        domain = f"""{self._letters(length=5)}.{random.choice(self.hostname_domains)}"""
+        return f"{prefix}.{domain}"
 
     def date_time(self) -> str:
         return datetime.now().strftime("%m%d%y%H%M%S")
@@ -85,11 +112,10 @@ class DMAFakerProvider(LoremProvider, InternetProvider):
         return f"{self._static_hostname}_{self._static_database_name}_{self._static_instance_name}_{date_time}"
 
     def user_name(self) -> str:
-        return super().user_name().upper()
+        return f"USER_{self._letters(length=4)}{self._digits(length=2)}"
 
 
-fake = Faker()
-fake.add_provider(DMAFakerProvider)
+fake = DMAFaker()
 
 
 class DataMaskTypes(Flag):


### PR DESCRIPTION
This PR adds column masking for

- PKEY
- DMA_SOURCE_ID
- hostname
- database name
- instance name

It also masks the collection key in both the archive file and the CSV files within the archive and keeps this key consistent between the two.

In dealing with `PKEY` and `DMA_SOURCE_ID` masking I added wildcard functionality to apply to all files.

I've reviewed the Oracle canonical tables and added the columns that need to be masked.

I wasn't sure if the **oracle_dataguard** table might have some hostname info in the connect string that might need to be looked at. I haven't dealt with this here.

I've manually tested this as far as possible but it does need more testing by another person IMO.

Finally, there are some formatting and minor changes from running the ruff linter and formatter over the file.

**Example maskings**

_Filename collection key_

Original

```
opdb_oracle_UseDiagnostics__121_4.3.29_rac194.wpuziewicz.com_O1211CDB_o1211cdb_013024142321.zip
opdb__archlogs__121_4.3.29_rac194.wpuziewicz.com_O1211CDB_o1211cdb_013024142321.csv
```

Masked

```
opdb_oracle_UseDiagnostics__121_4.3.29_db-76.cook.com_DB-SEASON_INST-CENTURY_013024142321.zip
opdb__archlogs__121_4.3.29_db-76.cook.com_DB-SEASON_INST-CENTURY_013024142321.csv

```

_PKEY, INSTANCE_NAME, HOST_NAME, DMA_SOURCE_ID_

Original

```
$ head sample-input/unzipped/opdb__dbinstances__121_4.3.29_rac194.wpuziewicz.com_O1211CDB_o1211cdb_013024142321.csv 
PKEY|INST_ID|INSTANCE_NAME|HOST_NAME|VERSION|STATUS|DATABASE_STATUS|INSTANCE_ROLE|DMA_SOURCE_ID|DMA_MANUAL_ID
rac194.wpuziewicz.com_O1211CDB_013024142321|1|o1211cdb|rac194.wpuziewicz.com|12.1.0.1.0|OPEN|ACTIVE|PRIMARY_INSTANCE|rac194.wpuziewicz.com_o1211cdb_1238643283|'NA'
```

Masked

```
$ head sample-output/unzipped/opdb__dbinstances__121_4.3.29_db-76.cook.com_DB-SEASON_INST-CENTURY_013024142321.csv 
PKEY|INST_ID|INSTANCE_NAME|HOST_NAME|VERSION|STATUS|DATABASE_STATUS|INSTANCE_ROLE|DMA_SOURCE_ID|DMA_MANUAL_ID
db-71.love.com_DB-STAND_030624180436|1|INST-TURN|desktop-50.white-duarte.com|12.1.0.1.0|OPEN|ACTIVE|PRIMARY_INSTANCE|email-85.jones-phillips.com_INST-PLAYER_6896483446|'NA'
```

_DATABASE_NAME_

Original

```
$ head sample-input/unzipped/opdb__pdbsinfo__121_4.3.29_rac194.wpuziewicz.com_O1211CDB_o1211cdb_013024142321.csv 
PKEY|DBID|PDB_ID|PDB_NAME|STATUS|LOGGING|CON_ID|CON_UID|EBS_OWNER|SIEBEL_OWNER|PSFT_OWNER|RDS_FLAG|OCI_AUTONOMOUS_FLAG|DBMS_CLOUD_PKG_INSTALLED|APEX_INSTALLED|SAP_OWNER|SGA_ALLOCATED_BYTES|PGA_USED_BYTES|PGA_ALLOCATED_BYTES|PGA_MAX_BYTES|DMA_SOURCE_ID|DMA_MANUAL_ID
rac194.wpuziewicz.com_O1211CDB_013024142321|74834048|2|PDB$SEED|NORMAL|N/A|1|74834048|||||||||1067118432|12391574|22969854|93027838|rac194.wpuziewicz.com_o1211cdb_1238643283|'NA'
rac194.wpuziewicz.com_O1211CDB_013024142321|1238643283|1|CDB$ROOT|NORMAL|LOGGING|1|1|||||||||1067118432|12391574|22969854|93027838|rac194.wpuziewicz.com_o1211cdb_1238643283|'NA'
rac194.wpuziewicz.com_O1211CDB_013024142321|2755328021|5|O12PDB3|NORMAL|N/A|1|2755328021|||||||||1067118432|12391574|22969854|93027838|rac194.wpuziewicz.com_o1211cdb_1238643283|'NA'
rac194.wpuziewicz.com_O1211CDB_013024142321|2805019465|4|O12PDB2|NORMAL|N/A|1|2805019465|||||||||1067118432|12391574|22969854|93027838|rac194.wpuziewicz.com_o1211cdb_1238643283|'NA'
rac194.wpuziewicz.com_O1211CDB_013024142321|3208678270|3|O12PDB1|NORMAL|N/A|1|3208678270|||||||||1067118432|12391574|22969854|93027838|rac194.wpuziewicz.com_o1211cdb_1238643283|'NA'
```

Masked

```
$ head sample-output/unzipped/opdb__pdbsinfo__121_4.3.29_db-76.cook.com_DB-SEASON_INST-CENTURY_013024142321.csv 
PKEY|DBID|PDB_ID|PDB_NAME|STATUS|LOGGING|CON_ID|CON_UID|EBS_OWNER|SIEBEL_OWNER|PSFT_OWNER|RDS_FLAG|OCI_AUTONOMOUS_FLAG|DBMS_CLOUD_PKG_INSTALLED|APEX_INSTALLED|SAP_OWNER|SGA_ALLOCATED_BYTES|PGA_USED_BYTES|PGA_ALLOCATED_BYTES|PGA_MAX_BYTES|DMA_SOURCE_ID|DMA_MANUAL_ID
db-71.love.com_DB-STAND_030624180436|74834048|2|DB-LATE|NORMAL|N/A|1|74834048|||||||||1067118432|12391574|22969854|93027838|email-85.jones-phillips.com_INST-PLAYER_6896483446|'NA'
db-71.love.com_DB-STAND_030624180436|1238643283|1|DB-CUT|NORMAL|LOGGING|1|1|||||||||1067118432|12391574|22969854|93027838|email-85.jones-phillips.com_INST-PLAYER_6896483446|'NA'
db-71.love.com_DB-STAND_030624180436|2755328021|5|DB-WRONG|NORMAL|N/A|1|2755328021|||||||||1067118432|12391574|22969854|93027838|email-85.jones-phillips.com_INST-PLAYER_6896483446|'NA'
db-71.love.com_DB-STAND_030624180436|2805019465|4|DB-LATER|NORMAL|N/A|1|2805019465|||||||||1067118432|12391574|22969854|93027838|email-85.jones-phillips.com_INST-PLAYER_6896483446|'NA'
db-71.love.com_DB-STAND_030624180436|3208678270|3|DB-INVOLVE|NORMAL|N/A|1|3208678270|||||||||1067118432|12391574|22969854|93027838|email-85.jones-phillips.com_INST-PLAYER_6896483446|'NA'
```

Note how each PDB has a unique masked name.