### PR TITLE
fix: set `3.8` compatible type hints

### DIFF
--- a/scripts/masker/dma-collection-masker
+++ b/scripts/masker/dma-collection-masker
@@ -272,9 +272,7 @@ def _mask_file_collection_key(collection_file: Path) -> Path:
         Path: masked collection key file path.
     """
     metadata = _metadata_from_filename(collection_file)
-    return collection_file.with_stem(
-        collection_file.stem.replace(metadata.collection_key, fake.collection_key)
-    )
+    return Path(f"{collection_file.with_name(collection_file.stem.replace(metadata.collection_key, fake.collection_key))}{collection_file.suffix}")
 
 
 def _find_collections_to_process(search_path: Path) -> List[Path]:

--- a/scripts/masker/dma-collection-masker
+++ b/scripts/masker/dma-collection-masker
@@ -50,10 +50,10 @@ FileMetadata = namedtuple(
 )
 
 
-class DMAFaker():
+class DMAFaker:
     """Fake data provider to provide masked values"""
 
-    hostname_prefixes: list[str] = [
+    hostname_prefixes: List[str] = [
         "db",
         "srv",
         "desktop",
@@ -63,7 +63,7 @@ class DMAFaker():
         "web",
     ]
 
-    hostname_domains: list[str] = [
+    hostname_domains: List[str] = [
         "com",
         "com",
         "com",


### PR DESCRIPTION
This PR change 2 type hints to the 3.8 style syntax.

`list[T]` vs `List[T]`