### PR TITLE
feat: Add "end of job" check for `oracle` 

### DIFF
--- a/scripts/collector/oracle/collect-data.sh
+++ b/scripts/collector/oracle/collect-data.sh
@@ -188,6 +188,10 @@ else
   echo "No Version file found" >  ${OUTPUT_DIR}/opdb__${V_FILE_TAG}_version.txt
 fi
 ERRCNT=$(wc -l < ${OUTPUT_DIR}/opdb__${V_FILE_TAG}_errors.log)
+if [ ! -f ${OUTPUT_DIR}/opdb__eoj__${V_FILE_TAG}.csv ] ; then
+	ERRCNT=$((${ERRCNT} + 1))
+	echo "End of job marker file not found.  Data collection did not complete."
+fi
 if [[ ${ERRCNT} -ne 0 ]]
 then
   V_ERR_TAG="_ERROR"

--- a/scripts/collector/oracle/sql/extracts/eoj.sql
+++ b/scripts/collector/oracle/sql/extracts/eoj.sql
@@ -1,0 +1,19 @@
+/*
+Copyright 2022 Google LLC
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    https://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+-- This file intentionally left empty
+spool &outputdir/opdb__eoj__&v_tag
+prompt END_OF_DMA_COLLECTION
+spool off

--- a/scripts/collector/oracle/sql/extracts/eoj.sql
+++ b/scripts/collector/oracle/sql/extracts/eoj.sql
@@ -1,5 +1,5 @@
 /*
-Copyright 2022 Google LLC
+Copyright 2024 Google LLC
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
@@ -13,7 +13,7 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 */
--- This file intentionally left empty
+-- This file intentionally has no extraction SQL.
 spool &outputdir/opdb__eoj__&v_tag
 prompt END_OF_DMA_COLLECTION
 spool off

--- a/scripts/collector/oracle/sql/op_collect.sql
+++ b/scripts/collector/oracle/sql/op_collect.sql
@@ -88,7 +88,7 @@ set termout &TERMOUTOFF
 @&SQLDIR/op_collect_&v_dodiagnostics
 @&EXTRACTSDIR/lobsizing.sql
 --@&EXTRACTSDIR/opatch.sql
-
+@&EXTRACTSDIR/eoj.sql
 
 set termout on
 prompt Step completed.


### PR DESCRIPTION
* Mark the extraction as "error" if the collector session is killed or disconnected from the database.