### PR TITLE
Reduce error prominence in dmaSQLServerHWSpecs.ps1

### DIFF
--- a/scripts/collector/sqlserver/dmaSQLServerHWSpecs.ps1
+++ b/scripts/collector/sqlserver/dmaSQLServerHWSpecs.ps1
@@ -66,6 +66,8 @@ param (
 	)][switch]$requestCreds
 )
 
+$ErrorActionPreference = 'Stop'
+
 Import-Module $PSScriptRoot\dmaCollectorCommonFunctions.psm1
 
 $params = @{
@@ -126,7 +128,7 @@ try {
 	WriteLog -logLocation $logLocation -logMessage "Successfully fetched machine HW specs of $computerName to output:$outputPath" -logOperation "FILE"
 }
 catch {
-	WriteLog -logLocation $logLocation -logMessage "ERROR - Failed fetching machine HW specs of $computerName" -logOperation "BOTH"
+	WriteLog -logLocation $logLocation -logMessage "ERROR - Failed fetching machine HW specs of ${computerName}: $_" -logOperation "BOTH"
 	# Write at least MachineName to CSV.
 	$csvData | Export-Csv -Path $outputPath -Delimiter "|" -NoTypeInformation -Encoding UTF8
 }


### PR DESCRIPTION
See b/340537974

Previously:

```
Get-WmiObject : The RPC server is unavailable.
At C:\Users\SguegliL\CCSG2\dmaSQLServerHWSpecs.ps1:107 char:31
+ ... ata.PhysicalCpuCount = (Get-WmiObject Win32_Processor @params | Measu ...
+                             ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
    + CategoryInfo          : InvalidOperation: (:) [Get-WmiObject], COMException
    + FullyQualifiedErrorId : GetWMICOMException,Microsoft.PowerShell.Commands.GetWmiObjectCommand
 
Get-WmiObject : The RPC server is unavailable.
At C:\Users\SguegliL\CCSG2\dmaSQLServerHWSpecs.ps1:110 char:30
+ ... Data.LogicalCpuCount = (Get-WmiObject Win32_Processor @params | Measu ...
+                             ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
    + CategoryInfo          : InvalidOperation: (:) [Get-WmiObject], COMException
    + FullyQualifiedErrorId : GetWMICOMException,Microsoft.PowerShell.Commands.GetWmiObjectCommand                                                                                                                                                                                                                                                                                          Get-WmiObject : The RPC server is unavailable.                                                                                                                                                At C:\Users\SguegliL\CCSG2\dmaSQLServerHWSpecs.ps1:113 char:33                                                                                                                                + ... alOSMemoryBytes = (Get-WmiObject Win32_PhysicalMemory @params | Measu ...                                                                                                               +                        ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
    + CategoryInfo          : InvalidOperation: (:) [Get-WmiObject], COMException
    + FullyQualifiedErrorId : GetWMICOMException,Microsoft.PowerShell.Commands.GetWmiObjectCommand
 
Get-WmiObject : The RPC server is unavailable.
At C:\Users\SguegliL\CCSG2\dmaSQLServerHWSpecs.ps1:119 char:25
+ ... Data.PrimaryMAC = (Get-WmiObject Win32_NetworkAdapter @params | Where ...
+                        ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
    + CategoryInfo          : InvalidOperation: (:) [Get-WmiObject], COMException
    + FullyQualifiedErrorId : GetWMICOMException,Microsoft.PowerShell.Commands.GetWmiObjectCommand
 
Get-WmiObject : The RPC server is unavailable.
At C:\Users\SguegliL\CCSG2\dmaSQLServerHWSpecs.ps1:122 char:26
+ ... ddresses = (Get-WmiObject Win32_NetworkAdapterConfiguration @params | ...
+                 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
    + CategoryInfo          : InvalidOperation: (:) [Get-WmiObject], COMException
    + FullyQualifiedErrorId : GetWMICOMException,Microsoft.PowerShell.Commands.GetWmiObjectCommand
```

After these changes:
```
ERROR - Failed fetching machine HW specs of not-a-vm : The RPC server is unavailable.
```