### PR TITLE
docs: Adding comment to user doc for `postgres`/`mysql` to use MC

### DIFF
--- a/docs/user_guide/mysql/collection_scripts.md
+++ b/docs/user_guide/mysql/collection_scripts.md
@@ -1,4 +1,4 @@
-## Please note: For Postgres homogenous migrations, please upload the collections files to Google Migration Center
+## Please note: For MySQL homogenous migrations, please upload the collections files to Google Migration Center
 
 
 # Gather workload metadata

--- a/docs/user_guide/mysql/collection_scripts.md
+++ b/docs/user_guide/mysql/collection_scripts.md
@@ -1,3 +1,6 @@
+## Please note: For Postgres homogenous migrations, please upload the collections files to Google Migration Center
+
+
 # Gather workload metadata
 
 The workload collection supports MySQL 5.6 and newer. Older versions of MySQL are not currently supported.  MariaDB is also not currently supported with this version of the script.

--- a/docs/user_guide/postgres/collection_scripts.md
+++ b/docs/user_guide/postgres/collection_scripts.md
@@ -1,3 +1,6 @@
+
+
+#celia
 # Gather workload metadata
 
 The workload collection supports Postgres 12 and newer. Older versions of Postgres are not currently supported.

--- a/docs/user_guide/postgres/collection_scripts.md
+++ b/docs/user_guide/postgres/collection_scripts.md
@@ -1,6 +1,6 @@
+## Please note: For Postgres homogenous migrations, please upload the collections files to Google Migration Center
 
 
-#celia
 # Gather workload metadata
 
 The workload collection supports Postgres 12 and newer. Older versions of Postgres are not currently supported.


### PR DESCRIPTION
For homogenous Postgres/mySQL, we need to direct users to upload these collections to MC. Added a comment in the user guide to reflect this