### PR TITLE
fix: Handle cases where the beginning of Statspack collection occurs within the collection window.

### DIFF
--- a/scripts/collector/oracle/sql/extracts/statspack/awrhistosstat.sql
+++ b/scripts/collector/oracle/sql/extracts/statspack/awrhistosstat.sql
@@ -57,7 +57,11 @@ WITH v_osstat_all
                        OVER (
                        PARTITION BY s.dbid, s.instance_number, osname.STAT_NAME
                        ORDER BY s.snap_id),
-                    0), 0) AS delta_value
+                    0), 0) AS delta_value,
+                     LAG(value)
+                       OVER (
+                       PARTITION BY s.dbid, s.instance_number, osname.STAT_NAME
+                       ORDER BY s.snap_id) AS lag_value
                     FROM STATS$OSSTAT s
                          inner join STATS$SNAPSHOT snap
                          ON s.snap_id = snap.snap_id
@@ -65,8 +69,9 @@ WITH v_osstat_all
                          AND s.dbid = snap.dbid
                          inner join STATS$OSSTATNAME osname
                          ON s.osstat_id = osname.osstat_id
-                    WHERE snap.snap_time BETWEEN (SELECT max(snap_time) FROM  STATS$SNAPSHOT WHERE snap_time < '&&v_min_snaptime'  ) AND '&&v_max_snaptime'
-                    AND s.dbid = '&&v_dbid') os ) ,
+                    WHERE snap.snap_time BETWEEN NVL((SELECT max(snap_time) FROM  STATS$SNAPSHOT WHERE snap_time < '&&v_min_snaptime'), '&&v_min_snaptime' ) AND '&&v_max_snaptime'
+                    AND s.dbid = '&&v_dbid') os
+              WHERE os.lag_value IS NOT NULL ),
 vossummary AS (
 SELECT :v_pkey AS pkey,
        dbid,


### PR DESCRIPTION
Handle cases where the beginning of Statspack collection occurs within the collection window.